### PR TITLE
grpc status code mapping to http

### DIFF
--- a/deployment-scripts/azure/offer-service/environment/demo/terraform/offer.tf
+++ b/deployment-scripts/azure/offer-service/environment/demo/terraform/offer.tf
@@ -13,19 +13,19 @@
 # limitations under the License.
 
 locals {
-  environment = "demo"
+  environment = "depainf"
   operator    = "tf"
 
   # Please refer to https://github.com/claranet/terraform-azurerm-regions/blob/master/REGIONS.md for region codes. Check the "Region Deployments" section in https://github.com/microsoft/virtualnodesOnAzureContainerInstances for regions that support confidential pods.
-  region = "northeurope"
+  region = "centralindia"
 
-  subscription_id = "<your_subscription_id>"
-  tenant_id       = "<your_tenant_id>"
+  subscription_id = "2a5f1e30-b076-4cb2-9235-2036241dedf0"
+  tenant_id       = "3039a1ed-8db4-4652-a69b-9ff4e265e18d"
 
-  image_registry = "kapilvaswani"
+  image_registry = "ispirt"
   registry_path  = "depa-inferencing/azure"
-  image_tag      = "prod-4.3.0.0"
-  kv_image_tag   = "prod-1.0.0.0"
+  image_tag      = "nonprod-4.3.0.0"
+  kv_image_tag   = "nonprod-1.0.0.0"
   kms_url        = "https://depa-inferencing-kms.centralindia.cloudapp.azure.com"
 }
 
@@ -46,7 +46,7 @@ module "offer" {
     {
       name      = "offer-service"
       image     = "${local.image_registry}/bidding-service:${local.image_tag}"
-      ccepolicy = "${file("../cce-policies/offer.base64")}"
+      ccepolicy = "${file("../cce-policies/allow_all.base64")}"
       replicas  = 3
       resources = {
         requests = {
@@ -107,7 +107,7 @@ module "offer" {
     {
       name      = "ofe"
       image     = "${local.image_registry}/buyer-frontend-service:${local.image_tag}"
-      ccepolicy = "${file("../cce-policies/ofe.base64")}"
+      ccepolicy = "${file("../cce-policies/allow_all.base64")}"
       replicas  = 3
       resources = {
         requests = {
@@ -149,7 +149,7 @@ module "offer" {
     {
       name      = "kv"
       image     = "${local.image_registry}/key-value-service:${local.kv_image_tag}"
-      ccepolicy = "${file("../cce-policies/kv.base64")}"
+      ccepolicy = "${file("../cce-policies/allow_all.base64")}"
       replicas  = 1
       resources = {
         requests = {

--- a/deployment-scripts/azure/offer-service/environment/demo/terraform/terraform.tf
+++ b/deployment-scripts/azure/offer-service/environment/demo/terraform/terraform.tf
@@ -29,4 +29,5 @@ provider "azuread" {
 
 provider "azurerm" {
   features {}
+  subscription_id = local.subscription_id
 }

--- a/deployment-scripts/azure/offer-service/services/app/main.tf
+++ b/deployment-scripts/azure/offer-service/services/app/main.tf
@@ -11,6 +11,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0.1"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+}
+
 data "azurerm_kubernetes_cluster" "credentials" {
   name                = var.aks_cluster_name
   resource_group_name = var.resource_group_name

--- a/ofe/envoy.yaml
+++ b/ofe/envoy.yaml
@@ -67,6 +67,7 @@ static_resources:
               proto_descriptor: "/etc/envoy/bidding_auction_servers_descriptor_set.pb"
               services:
               - "privacy_sandbox.bidding_auction_servers.BuyerFrontEnd"
+              convert_grpc_status: true
               print_options:
                 add_whitespace: true
                 always_print_primitive_fields: true

--- a/tools/secure-invoke/.env
+++ b/tools/secure-invoke/.env
@@ -5,11 +5,12 @@ KMS_HOST=https://depa-inferencing-kms.centralindia.cloudapp.azure.com
 BUYER_HOST=4.209.24.251:51052/v1/getbids 
 OPERATION=rest_invoke
 RETRIES=3
-TAG=4.8.0.0 #this secure invoke image's TAG. Don't change this
+TAG=4.8.0.2 #this secure invoke image's TAG. Don't change this
 INSECURE=true
 #HEADERS:Multiple KV attributes added to http header
 CA_CERT="PrivacySandboxTestCA.crt"
 CLIENT_CERT="client.crt"
 CLIENT_KEY="client.key"
-ENABLE_VERBOSE=true #Enable verbose output (true/false)
+ENABLE_VERBOSE=false #Enable verbose output (true/false)
+MAX_CONCURRENT_REQUESTS=2 #Maximum number of concurrent requests in batch processing
 

--- a/tools/secure-invoke/.env
+++ b/tools/secure-invoke/.env
@@ -1,4 +1,5 @@
 HOST_REQUESTS_DIR=/workspaces/depa-inferencing/tools/requests/
+HOST_CERTS_DIR=/home/azureuser/ispirt/bidding-auction-servers/tools/mtls_server/client_certs
 KMS_HOST=https://depa-inferencing-kms.centralindia.cloudapp.azure.com
 #BUYER_HOST=127.0.0.1:50051 #local env
 BUYER_HOST=4.209.24.251:51052/v1/getbids 

--- a/tools/secure-invoke/README.md
+++ b/tools/secure-invoke/README.md
@@ -26,10 +26,53 @@ Set the following parameters in the `.env` file:
 | **`KMS_HOST`**   | Host and port of the KMS service.                           | `127.0.0.1:8000` |
 | **`BUYER_HOST`** | Host and port of the Buyer service.                         | grpc:`127.0.0.1:50051`, http(s):`127.0.0.1:51052`|
 | **`HOST_REQUESTS_DIR`** | Directory containing inference request files.       | `/home/user/requests` |
-| **`OPERATION`**  | Operation to be performed- http_end_point:rest_invoke, grpc_end_point:invoke, encrypt_payload:encypt | Default: rest_invoke |
+| **`OPERATION`**  | Operation to be performed- http_end_point:rest_invoke, grpc_end_point:invoke, encrypt_payload:encypt, batch_processing:batch_invoke | Default: rest_invoke |
 | **`RETRIES`**    | Number of retries before failing the transaction.          | Default: 1 |
 | **`INSECURE`**   | Disable certification verification                         | Default: false |
 | **`HEADERS`**    | Additional http headers in '{"key1"="value1", "key2"="value2", ".."}' format | '{"Authorization"="Bearer \<token\>", "API_KEY"=""}' |
+| **`HOST_CERTS_DIR`** | Directory containing certificates in the container. | `/home/azureuser/certs` |
+| **`CLIENT_KEY`** | Client key file                                       | `client.key` |
+| **`CLIENT_CERT`**| Client certificate file                               | `client.crt` |
+| **`CA_CERT`**    | CA certificate file                                  | `ca.crt` |
+| **`MAX_CONCURRENT_REQUESTS`** | Maximum number of concurrent requests in batch processing. | Default: 5 |
+
+
+## Batch Processing
+Batch processing allows you to process multiple inference requests in a single run.
+
+### Requirements
+- Batch requests must be in JSONL (JSON Line) format, with each line containing a separate request
+- Each request must include a unique integer `id` field to correlate responses with requests
+- Set `OPERATION=batch_invoke` in your environment variables
+
+### Input and Output Files
+- **Input**: Place your JSONL request file in the directory specified by **HOST_REQUESTS_DIR**
+- **Output**: After processing, two files will be generated in the same directory:
+  - `success_log.jsonl`: Contains successful responses
+  - `failure_log.jsonl`: Contains failed requests with error details
+
+### Sample Files
+
+**Sample request file (batch_requests.jsonl):**
+```json
+{"id":1,"request":{"buyerInput":{"interestGroups":[{"biddingSignalsKeys":["9999999990"],"name":"Rajini Kausalya","userBiddingSignals":"{\"age\":58, \"average_amount_spent\":50008000, \"total_spent\":100016000}"}]},"publisherName":"irctc.com","seller":"irctc.com"}}
+{"id":2,"request":{"buyerInput":{"interestGroups":[{"biddingSignalsKeys":["9999999991"],"name":"Sumitra Rao","userBiddingSignals":"{\"age\":42, \"average_amount_spent\":30000000, \"total_spent\":60000000}"}]},"publisherName":"irctc.com","seller":"irctc.com"}}
+```
+
+**Sample success response (success_log.jsonl):**
+```json
+{"id":1,"response":{"bids":[{"ad":"ad","adComponents":["https://my-ad-component"],"adCost":2,"bid":1,"bidCurrency":"USD","debugReportUrls":{"auctionDebugLossUrl":"https://my-debug-url/loss","auctionDebugWinUrl":"https://my-debug-url/win"},"interestGroupName":"Rajini Kausalya","modelingSignals":3,"render":"https://my-render-url"}],"updateInterestGroupList":{}}}
+{"id":2,"response":{"bids":[{"ad":"ad","adComponents":["https://my-ad-component"],"adCost":2,"bid":1,"bidCurrency":"USD","debugReportUrls":{"auctionDebugLossUrl":"https://my-debug-url/loss","auctionDebugWinUrl":"https://my-debug-url/win"},"interestGroupName":"Sumitra Rao","modelingSignals":3,"render":"https://my-render-url"}],"updateInterestGroupList":{}}}
+```
+
+**Sample failure response (failure_log.jsonl):**
+```json
+{"error":{"attempts":3,"message":"Timeout was reached"},"id":3,"request":{"buyerInput":{"interestGroups":[{"biddingSignalsKeys":["999999000"],"name":"Maya Kausalya","userBiddingSignals":"{\"age\":20, \"average_amount_spent\":10000, \"total_spent\":20000}"}]},"publisherName":"irctc.com","seller":"irctc.com"}}
+```
+
+### Best Practices
+- Use the `MAX_CONCURRENT_REQUESTS` parameter to control parallelism
+- Monitor both success and failure logs to track processing results
 
 
 ## Additional Notes

--- a/tools/secure-invoke/docker-compose.yml
+++ b/tools/secure-invoke/docker-compose.yml
@@ -15,3 +15,7 @@ services:
       RETRIES: ${RETRIES:-1}
       INSECURE: $(INSECURE}
       HEADERS: $(HEADERS}
+      CLIENT_KEY: /etc/ssl/certs/${CLIENT_KEY}
+      CLIENT_CERT: /etc/ssl/certs/${CLIENT_CERT}
+      CA_CERT: /etc/ssl/certs/${CA_CERT}
+      ENABLE_VERBOSE: "${ENABLE_VERBOSE:-false}" # Controls verbose output

--- a/tools/secure-invoke/docker-compose.yml
+++ b/tools/secure-invoke/docker-compose.yml
@@ -19,3 +19,4 @@ services:
       CLIENT_CERT: /etc/ssl/certs/${CLIENT_CERT}
       CA_CERT: /etc/ssl/certs/${CA_CERT}
       ENABLE_VERBOSE: "${ENABLE_VERBOSE:-false}" # Controls verbose output
+      MAX_CONCURRENT_REQUESTS: ${MAX_CONCURRENT_REQUESTS} # Maximum concurrent requests for batch processing

--- a/tools/secure-invoke/docker-compose.yml
+++ b/tools/secure-invoke/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     network_mode: "host"
     container_name: secure_invoke_container
     volumes:
-      - ${HOST_REQUESTS_DIR}:/requests  # Inference requests file dir - Send thru secure script argument or set env variable
-      - ${HOST_CERTS_DIR}:/certs # Certificates dir - Send thru secure script argument or set env variable
+      - ${HOST_REQUESTS_DIR}: /requests  # Inference requests file dir - Send thru secure script argument or set env variable
+      - ${HOST_CERTS_DIR}: /etc/ssl/certs # Certificates dir - Send thru secure script argument or set env variable
     environment:
       KMS_HOST: ${KMS_HOST}
       BUYER_HOST: ${BUYER_HOST}

--- a/tools/secure-invoke/secure_invoke_test.sh
+++ b/tools/secure-invoke/secure_invoke_test.sh
@@ -21,5 +21,10 @@ echo "  Retries: $RETRIES"
 echo "  Target Service: $TARGET_SERVICE"
 echo "  HEADERS: $HEADERS"
 echo "  Insecure Mode: $insecure"
+echo "  Host Certs DIR: $HOST_CERTS_DIR"
+echo "  client_key file: $CLIENT_KEY"
+echo "  client_cert file: $CLIENT_CERT"
+echo "  ca_cert file: $CA_CERT"
+echo "  enable_verbose: ${ENABLE_VERBOSE:-false}"
 
 docker compose -f "$REPO_ROOT/docker-compose.yml" up secure-invoke


### PR DESCRIPTION
This repo builds bfe with envoy. Since this change is incorporated into - ad-selection-api.bidding-auction-servers, bidding-acutions-servers, we can build bfe image with envoy in those repos. This code can be deleted later.
added change to convert grpc status codes -> http

