### PR TITLE
policy updates

### DIFF
--- a/policies/kv.json
+++ b/policies/kv.json
@@ -4,343 +4,282 @@
   "parameters": {
     "containerGroupName": {
       "type": "string",
-      "defaultValue": "kv-aci",
       "metadata": {
         "description": "Name for the container group"
       }
     },
     "location": {
       "type": "string",
-      "defaultValue": "centralindia",
       "metadata": {
         "description": "Location for all resources"
       }
     },
     "cpu": {
       "type": "int",
-      "defaultValue": 4,
       "metadata": {
         "description": "Number of CPU cores"
       }
     },
     "memoryInGb": {
       "type": "string",
-      "defaultValue": "16",
       "metadata": {
         "description": "Amount of memory in GB"
       }
     },
     "port": {
       "type": "int",
-      "defaultValue": 50051,
       "metadata": {
         "description": "Port to expose on the container group"
       }
     },
     "dnsLabelPrefix": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "DNS label prefix for the container group"
       }
     },
     "registryServer": {
       "type": "string",
-      "defaultValue": "ispirt.azurecr.io",
       "metadata": {
         "description": "Container registry server"
       }
     },
-    "registryUsername": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Container registry username"
-      }
-    },
-    "registryPassword": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Container registry password"
-      }
-    },
     "env_KV_PORT": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "KV_PORT environment variable"
       }
     },
     "env_KV_HEALTHCHECK_PORT": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "KV_HEALTHCHECK_PORT environment variable"
       }
     },
     "env_AZURE_LOCAL_DATA_DIR": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "AZURE_LOCAL_DATA_DIR environment variable"
       }
     },
     "env_AZURE_LOCAL_REALTIME_DATA_DIR": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "AZURE_LOCAL_REALTIME_DATA_DIR environment variable"
       }
     },
     "env_AD_RETRIEVAL_KV_SERVER_ADDR": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "AD_RETRIEVAL_KV_SERVER_ADDR environment variable"
       }
     },
     "env_AD_RETRIEVAL_KV_SERVER_EGRESS_TLS": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "AD_RETRIEVAL_KV_SERVER_EGRESS_TLS environment variable"
       }
     },
     "env_AD_RETRIEVAL_TIMEOUT_MS": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "AD_RETRIEVAL_TIMEOUT_MS environment variable"
       }
     },
     "env_BUYER_EGRESS_TLS": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "BUYER_EGRESS_TLS environment variable"
       }
     },
     "env_COLLECTOR_ENDPOINT": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "COLLECTOR_ENDPOINT environment variable"
       }
     },
     "env_CONSENTED_DEBUG_TOKEN": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "CONSENTED_DEBUG_TOKEN environment variable"
       }
     },
     "env_ENABLE_AUCTION_COMPRESSION": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "ENABLE_AUCTION_COMPRESSION environment variable"
       }
     },
     "env_ENABLE_BUYER_COMPRESSION": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "ENABLE_BUYER_COMPRESSION environment variable"
       }
     },
     "env_ENABLE_CHAFFING": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "ENABLE_CHAFFING environment variable"
       }
     },
     "env_ENABLE_OTEL_BASED_LOGGING": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "ENABLE_OTEL_BASED_LOGGING environment variable"
       }
     },
     "env_ENABLE_PROTECTED_APP_SIGNALS": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "ENABLE_PROTECTED_APP_SIGNALS environment variable"
       }
     },
     "env_INFERENCE_MODEL_BUCKET_NAME": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "INFERENCE_MODEL_BUCKET_NAME environment variable"
       }
     },
     "env_INFERENCE_MODEL_BUCKET_PATHS": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "INFERENCE_MODEL_BUCKET_PATHS environment variable"
       }
     },
     "env_INFERENCE_MODEL_CONFIG_PATH": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "INFERENCE_MODEL_CONFIG_PATH environment variable"
       }
     },
     "env_INFERENCE_MODEL_FETCH_PERIOD_MS": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "INFERENCE_MODEL_FETCH_PERIOD_MS environment variable"
       }
     },
     "env_INFERENCE_MODEL_LOCAL_PATHS": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "INFERENCE_MODEL_LOCAL_PATHS environment variable"
       }
     },
     "env_INFERENCE_SIDECAR_BINARY_PATH": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "INFERENCE_SIDECAR_BINARY_PATH environment variable"
       }
     },
     "env_K_ANONYMITY_SERVER_ADDR": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "K_ANONYMITY_SERVER_ADDR environment variable"
       }
     },
     "env_K_ANONYMITY_SERVER_TIMEOUT_MS": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "K_ANONYMITY_SERVER_TIMEOUT_MS environment variable"
       }
     },
     "env_KV_SERVER_EGRESS_TLS": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "KV_SERVER_EGRESS_TLS environment variable"
       }
     },
     "env_MAX_ALLOWED_SIZE_DEBUG_URL_BYTES": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "MAX_ALLOWED_SIZE_DEBUG_URL_BYTES environment variable"
       }
     },
     "env_MAX_ALLOWED_SIZE_ALL_DEBUG_URLS_KB": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "MAX_ALLOWED_SIZE_ALL_DEBUG_URLS_KB environment variable"
       }
     },
     "env_PS_VERBOSITY": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "PS_VERBOSITY environment variable"
       }
     },
     "env_ROMA_TIMEOUT_MS": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "ROMA_TIMEOUT_MS environment variable"
       }
     },
     "env_SELECTION_KV_SERVER_ADDR": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "SELECTION_KV_SERVER_ADDR environment variable"
       }
     },
     "env_SELECTION_KV_SERVER_EGRESS_TLS": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "SELECTION_KV_SERVER_EGRESS_TLS environment variable"
       }
     },
     "env_SELECTION_KV_SERVER_TIMEOUT_MS": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "SELECTION_KV_SERVER_TIMEOUT_MS environment variable"
       }
     },
     "env_TEE_AD_RETRIEVAL_KV_SERVER_ADDR": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "TEE_AD_RETRIEVAL_KV_SERVER_ADDR environment variable"
       }
     },
     "env_TEE_KV_SERVER_ADDR": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "TEE_KV_SERVER_ADDR environment variable"
       }
     },
     "env_TELEMETRY_CONFIG": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "TELEMETRY_CONFIG environment variable"
       }
     },
     "env_AZURE_BA_PARAM_GET_TOKEN_URL": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "AZURE_BA_PARAM_GET_TOKEN_URL environment variable"
       }
     },
     "env_ENABLE_PROTECTED_AUDIENCE": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "ENABLE_PROTECTED_AUDIENCE environment variable"
       }
     },
     "env_KEY_REFRESH_FLOW_RUN_FREQUENCY_SECONDS": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "KEY_REFRESH_FLOW_RUN_FREQUENCY_SECONDS environment variable"
       }
     },
     "env_PRIMARY_COORDINATOR_ACCOUNT_IDENTITY": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "PRIMARY_COORDINATOR_ACCOUNT_IDENTITY environment variable"
       }
     },
     "env_PRIMARY_COORDINATOR_REGION": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "PRIMARY_COORDINATOR_REGION environment variable"
       }
     },
     "env_PRIVATE_KEY_CACHE_TTL_SECONDS": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "PRIVATE_KEY_CACHE_TTL_SECONDS environment variable"
       }
@@ -356,9 +295,6 @@
       "properties": {
         "osType": "Linux",
         "sku": "Confidential",
-        "confidentialComputeProperties": {
-            "ccePolicy": "cGFja2FnZSBwb2xpY3kKCmFwaV9zdm4gOj0gIjAuMTAuMCIKCm1vdW50X2RldmljZSA6PSB7ImFsbG93ZWQiOiB0cnVlfQptb3VudF9vdmVybGF5IDo9IHsiYWxsb3dlZCI6IHRydWV9CmNyZWF0ZV9jb250YWluZXIgOj0geyJhbGxvd2VkIjogdHJ1ZSwgImFsbG93X3N0ZGlvX2FjY2VzcyI6IHRydWV9CnVubW91bnRfZGV2aWNlIDo9IHsiYWxsb3dlZCI6IHRydWV9CnVubW91bnRfb3ZlcmxheSA6PSB7ImFsbG93ZWQiOiB0cnVlfQpleGVjX2luX2NvbnRhaW5lciA6PSB7ImFsbG93ZWQiOiB0cnVlfQpleGVjX2V4dGVybmFsIDo9IHsiYWxsb3dlZCI6IHRydWUsICJhbGxvd19zdGRpb19hY2Nlc3MiOiB0cnVlfQpzaHV0ZG93bl9jb250YWluZXIgOj0geyJhbGxvd2VkIjogdHJ1ZX0Kc2lnbmFsX2NvbnRhaW5lcl9wcm9jZXNzIDo9IHsiYWxsb3dlZCI6IHRydWV9CnBsYW45X21vdW50IDo9IHsiYWxsb3dlZCI6IHRydWV9CnBsYW45X3VubW91bnQgOj0geyJhbGxvd2VkIjogdHJ1ZX0KZ2V0X3Byb3BlcnRpZXMgOj0geyJhbGxvd2VkIjogdHJ1ZX0KZHVtcF9zdGFja3MgOj0geyJhbGxvd2VkIjogdHJ1ZX0KcnVudGltZV9sb2dnaW5nIDo9IHsiYWxsb3dlZCI6IHRydWV9CmxvYWRfZnJhZ21lbnQgOj0geyJhbGxvd2VkIjogdHJ1ZX0Kc2NyYXRjaF9tb3VudCA6PSB7ImFsbG93ZWQiOiB0cnVlfQpzY3JhdGNoX3VubW91bnQgOj0geyJhbGxvd2VkIjogdHJ1ZX0="
-        },
         "restartPolicy": "Always",
         "ipAddress": {
           "type": "Public",
@@ -374,7 +310,7 @@
           {
             "name": "[parameters('containerGroupName')]",
             "properties": {
-              "image": "ispirt.azurecr.io/depa-inferencing/azure/key-value-service:nonprod-1.2.0.0",
+              "image": "ispirt.azurecr.io/depa-inferencing/azure/key-value-service:nonprod-1.0.0.0",
               "resources": {
                 "requests": {
                   "cpu": "[parameters('cpu')]",

--- a/policies/ofe.json
+++ b/policies/ofe.json
@@ -10,291 +10,387 @@
     },
     "location": {
       "type": "string",
-      "defaultValue": "[resourceGroup().location]",
       "metadata": {
         "description": "Location for all resources. Defaults to the resource group's location."
       }
     },
     "cpu": {
       "type": "int",
-      "defaultValue": 4,
       "metadata": {
         "description": "CPU cores for the container"
       }
     },
     "memoryInGb": {
       "type": "string",
-      "defaultValue": "16",
       "metadata": {
         "description": "Memory (in GB) for the container"
       }
     },
     "port": {
       "type": "int",
-      "defaultValue": 50051,
       "metadata": {
         "description": "Container and public port to expose"
       }
     },
     "dnsLabelPrefix": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "Public DNS label prefix for the container group's IP (must be globally unique in region). Leave empty to omit."
       }
     },
     "registryServer": {
       "type": "string",
-      "defaultValue": "ispirt.azurecr.io",
       "metadata": {
         "description": "Container registry login server"
       }
     },
-    "registryUsername": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Container registry username (leave empty if using managed identity)"
-      }
-    },
-    "registryPassword": {
-      "type": "secureString",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Container registry password (leave empty if using managed identity)"
-      }
-    },
     "env_BFE_INGRESS_TLS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "TLS configuration for BFE ingress traffic"
+      }
     },
     "env_BFE_TCMALLOC_BACKGROUND_RELEASE_RATE_BYTES_PER_SECOND": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Background release rate for TCMalloc memory management in BFE service"
+      }
     },
     "env_BFE_TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Maximum total thread cache size for TCMalloc in BFE service"
+      }
     },
     "env_BFE_TLS_CERT": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "TLS certificate for BFE ingress traffic"
+      }
     },
     "env_BFE_TLS_KEY": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "TLS key for BFE ingress traffic"
+      }
     },
     "env_BIDDING_EGRESS_TLS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "TLS configuration for BFE ingress traffic"
+      }
     },
     "env_BIDDING_SERVER_ADDR": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Bidding service address"
+      }
     },
     "env_BIDDING_SIGNALS_LOAD_TIMEOUT_MS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Bidding signals load timeout in milliseconds"
+      }
     },
     "env_BUYER_FRONTEND_HEALTHCHECK_PORT": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Buyer frontend healthcheck port"
+      }
     },
     "env_BUYER_FRONTEND_PORT": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Buyer frontend port"
+      }
     },
     "env_BUYER_KV_SERVER_ADDR": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Buyer KV server address"
+      }
     },
     "env_ENABLE_TKV_V2": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Enable TKV V2"
+      }
     },
     "env_ENABLE_TKV_V2_BROWSER": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Enable TKV V2 browser"
+      }
     },
     "env_BUYER_TKV_V2_SERVER_ADDR": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Buyer TKV V2 server address"
+      }
     },
     "env_TKV_EGRESS_TLS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "TLS configuration for TKV ingress traffic"
+      }
     },
     "env_BYOS_AD_RETRIEVAL_SERVER": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "BYOS ad retrieval server"
+      }
     },
     "env_CREATE_NEW_EVENT_ENGINE": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Create new event engine"
+      }
     },
     "env_ENABLE_BIDDING_COMPRESSION": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Enable bidding compression"
+      }
     },
     "env_ENABLE_BUYER_FRONTEND_BENCHMARKING": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Enable buyer frontend benchmarking"
+      }
     },
     "env_GENERATE_BID_TIMEOUT_MS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Generate bid timeout in milliseconds"
+      }
     },
     "env_GRPC_ARG_DEFAULT_AUTHORITY": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "gRPC arg default authority"
+      }
     },
     "env_PROTECTED_APP_SIGNALS_GENERATE_BID_TIMEOUT_MS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Protected app signals generate bid timeout in milliseconds"
+      }
     },
     "env_AZURE_BA_PARAM_GET_TOKEN_URL": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Azure BA param get token URL"
+      }
     },
     "env_ENABLE_PROTECTED_AUDIENCE": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Enable protected audience"
+      }
     },
     "env_KEY_REFRESH_FLOW_RUN_FREQUENCY_SECONDS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Key refresh flow run frequency seconds"
+      }
     },
     "env_PRIMARY_COORDINATOR_ACCOUNT_IDENTITY": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Primary coordinator account identity"
+      }
     },
     "env_PRIMARY_COORDINATOR_REGION": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Primary coordinator region"
+      }
     },
     "env_PRIVATE_KEY_CACHE_TTL_SECONDS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Private key cache TTL seconds"
+      }
     },
     "env_TELEMETRY_CONFIG": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Telemetry config"
+      }
     },
     "env_COLLECTOR_ENDPOINT": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Collector endpoint"
+      }
     },
     "env_BUYER_EGRESS_TLS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Buyer egress TLS"
+      }
     },
     "env_CONSENTED_DEBUG_TOKEN": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Consented debug token"
+      }
     },
     "env_ENABLE_AUCTION_COMPRESSION": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Enable auction compression"
+      }
     },
     "env_ENABLE_BUYER_COMPRESSION": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Enable buyer compression"
+      }
     },
     "env_ENABLE_CHAFFING": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Enable chaffing"
+      }
     },
     "env_ENABLE_OTEL_BASED_LOGGING": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Enable OTEL based logging"
+      }
     },
     "env_ENABLE_PROTECTED_APP_SIGNALS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Enable protected app signals"
+      }
     },
     "env_KV_SERVER_EGRESS_TLS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "KV server egress TLS"
+      }
     },
     "env_MAX_ALLOWED_SIZE_DEBUG_URL_BYTES": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Max allowed size for debug URL bytes"
+      }
     },
     "env_MAX_ALLOWED_SIZE_ALL_DEBUG_URLS_KB": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Max allowed size for all debug URLs in KB"
+      }
     },
     "env_PS_VERBOSITY": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "PS verbosity"
+      }
     },
     "env_ROMA_TIMEOUT_MS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Roma timeout in milliseconds"
+      }
     },
     "env_TEE_AD_RETRIEVAL_KV_SERVER_ADDR": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "TEE ad retrieval KV server address"
+      }
     },
     "env_TEE_KV_SERVER_ADDR": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "TEE KV server address"
+      }
     },
     "env_AD_RETRIEVAL_KV_SERVER_ADDR": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "AD retrieval KV server address"
+      }
     },
     "env_AD_RETRIEVAL_KV_SERVER_EGRESS_TLS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "AD retrieval KV server egress TLS"
+      }
     },
     "env_AD_RETRIEVAL_TIMEOUT_MS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "AD retrieval timeout in milliseconds"
+      }
     },
     "env_INFERENCE_MODEL_BUCKET_NAME": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Inference model bucket name"
+      }
     },
     "env_INFERENCE_MODEL_BUCKET_PATHS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Inference model bucket paths"
+      }
     },
     "env_INFERENCE_MODEL_CONFIG_PATH": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Inference model config path"
+      }
     },
     "env_INFERENCE_MODEL_FETCH_PERIOD_MS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Inference model fetch period in milliseconds"
+      }
     },
     "env_INFERENCE_MODEL_LOCAL_PATHS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Inference model local paths"
+      }
     },
     "env_INFERENCE_SIDECAR_BINARY_PATH": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Inference sidecar binary path"
+      }
     },
     "env_K_ANONYMITY_SERVER_ADDR": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "K anonymity server address"
+      }
     },
     "env_K_ANONYMITY_SERVER_TIMEOUT_MS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "K anonymity server timeout in milliseconds"
+      }
     },
     "env_SELECTION_KV_SERVER_ADDR": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Selection KV server address"
+      }
     },
     "env_SELECTION_KV_SERVER_EGRESS_TLS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Selection KV server egress TLS"
+      }
     },
     "env_SELECTION_KV_SERVER_TIMEOUT_MS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Selection KV server timeout in milliseconds"
+      }
     }
   },
   "variables": {},
@@ -580,9 +676,6 @@
         ],
         "osType": "Linux",
         "sku": "Confidential",
-        "confidentialComputeProperties": {
-          "ccePolicy": "ewo="
-        },
         "restartPolicy": "Always",
         "ipAddress": {
           "type": "Public",

--- a/policies/ofe.parameters.json
+++ b/policies/ofe.parameters.json
@@ -62,7 +62,7 @@
     "env_ENABLE_TKV_V2_BROWSER": {
       "value": "true"
     },
-    "env_TKV_V2_SERVER_ADDR": {
+    "env_BUYER_TKV_V2_SERVER_ADDR": {
       "value": "kv.ad_selection.microsoft:50051"
     },
     "env_TKV_EGRESS_TLS": {

--- a/policies/offer.json
+++ b/policies/offer.json
@@ -10,251 +10,339 @@
     },
     "location": {
       "type": "string",
-      "defaultValue": "[resourceGroup().location]",
       "metadata": {
         "description": "Location for all resources. Defaults to the resource group's location."
       }
     },
     "cpu": {
       "type": "int",
-      "defaultValue": 4,
       "metadata": {
         "description": "CPU cores for the container"
       }
     },
     "memoryInGb": {
       "type": "string",
-      "defaultValue": "16",
       "metadata": {
         "description": "Memory (in GB) for the container"
       }
     },
     "port": {
       "type": "int",
-      "defaultValue": 50057,
       "metadata": {
         "description": "Container and public port to expose"
       }
     },
     "dnsLabelPrefix": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "Public DNS label prefix for the container group's IP (must be globally unique in region). Leave empty to omit."
       }
     },
     "registryServer": {
       "type": "string",
-      "defaultValue": "ispirt.azurecr.io",
       "metadata": {
         "description": "Container registry login server"
       }
     },
     "registryUsername": {
       "type": "string",
-      "defaultValue": "",
       "metadata": {
         "description": "Container registry username (leave empty if using managed identity)"
       }
     },
     "registryPassword": {
       "type": "secureString",
-      "defaultValue": "",
       "metadata": {
         "description": "Container registry password (leave empty if using managed identity)"
       }
     },
     "env_BIDDING_HEALTHCHECK_PORT": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Bidding healthcheck port"
+      }
     },
     "env_BIDDING_PORT": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Bidding port"
+      }
     },
     "env_BIDDING_TCMALLOC_BACKGROUND_RELEASE_RATE_BYTES_PER_SECOND": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Background release rate for TCMalloc memory management in Bidding service"
+      }
     },
     "env_BIDDING_TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Maximum total thread cache size for TCMalloc in Bidding service"
+      }
     },
     "env_BUYER_CODE_FETCH_CONFIG": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Buyer code fetch config"
+      }
     },
     "env_EGRESS_SCHEMA_FETCH_CONFIG": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Egress schema fetch config"
+      }
     },
     "env_ENABLE_BIDDING_SERVICE_BENCHMARK": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Enable bidding service benchmark"
+      }
     },
     "env_INFERENCE_SIDECAR_RUNTIME_CONFIG": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Inference sidecar runtime config"
+      }
     },
     "env_UDF_NUM_WORKERS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "UDF number of workers"
+      }
     },
     "env_JS_WORKER_QUEUE_LEN": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "JS worker queue length"
+      }
     },
     "env_SELECTION_KV_SERVER_ADDR": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Selection KV server address"
+      }
     },
     "env_SELECTION_KV_SERVER_EGRESS_TLS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Selection KV server egress TLS"
+      }
     },
     "env_SELECTION_KV_SERVER_TIMEOUT_MS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Selection KV server timeout in milliseconds"
+      }
     },
     "env_TEE_AD_RETRIEVAL_KV_SERVER_GRPC_ARG_DEFAULT_AUTHORITY": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "TEE ad retrieval KV server gRPC arg default authority"
+      }
     },
     "env_TEE_KV_SERVER_GRPC_ARG_DEFAULT_AUTHORITY": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "TEE KV server gRPC arg default authority"
+      }
     },
     "env_AZURE_BA_PARAM_GET_TOKEN_URL": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Azure BA param get token URL"
+      }
     },
     "env_ENABLE_PROTECTED_AUDIENCE": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Enable protected audience"
+      }
     },
     "env_KEY_REFRESH_FLOW_RUN_FREQUENCY_SECONDS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Key refresh flow run frequency seconds"
+      }
     },
     "env_PRIMARY_COORDINATOR_ACCOUNT_IDENTITY": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Primary coordinator account identity"
+      }
     },
     "env_PRIMARY_COORDINATOR_REGION": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Primary coordinator region"
+      }
     },
     "env_PRIVATE_KEY_CACHE_TTL_SECONDS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Private key cache TTL seconds"
+      }
     },
     "env_TELEMETRY_CONFIG": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Telemetry config"
+      }
     },
     "env_COLLECTOR_ENDPOINT": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Collector endpoint"
+      }
     },
     "env_BUYER_EGRESS_TLS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Buyer egress TLS"
+      }
     },
     "env_CONSENTED_DEBUG_TOKEN": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Consented debug token"
+      }
     },
     "env_ENABLE_AUCTION_COMPRESSION": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Enable auction compression"
+      }
     },
     "env_ENABLE_BUYER_COMPRESSION": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Enable buyer compression"
+      }
     },
     "env_ENABLE_CHAFFING": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Enable chaffing"
+      }
     },
     "env_ENABLE_OTEL_BASED_LOGGING": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Enable OTEL based logging"
+      }
     },
     "env_ENABLE_PROTECTED_APP_SIGNALS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Enable protected app signals"
+      }
     },
     "env_INFERENCE_MODEL_BUCKET_NAME": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Inference model bucket name"
+      }
     },
     "env_INFERENCE_MODEL_BUCKET_PATHS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Inference model bucket paths"
+      }
     },
     "env_INFERENCE_MODEL_CONFIG_PATH": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Inference model config path"
+      }
     },
     "env_INFERENCE_MODEL_FETCH_PERIOD_MS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Inference model fetch period in milliseconds"
+      }
     },
     "env_INFERENCE_MODEL_LOCAL_PATHS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Inference model local paths"
+      }
     },
     "env_INFERENCE_SIDECAR_BINARY_PATH": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Inference sidecar binary path"
+      }
     },
     "env_K_ANONYMITY_SERVER_ADDR": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "K anonymity server address"
+      }
     },
     "env_K_ANONYMITY_SERVER_TIMEOUT_MS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "K anonymity server timeout in milliseconds"
+      }
     },
     "env_KV_SERVER_EGRESS_TLS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "KV server egress TLS"
+      }
     },
     "env_MAX_ALLOWED_SIZE_DEBUG_URL_BYTES": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Max allowed size for debug URL bytes"
+      }
     },
     "env_MAX_ALLOWED_SIZE_ALL_DEBUG_URLS_KB": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Max allowed size for all debug URLs in KB"
+      }
     },
     "env_PS_VERBOSITY": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "PS verbosity"
+      }
     },
     "env_ROMA_TIMEOUT_MS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "Roma timeout in milliseconds"
+      }
     },
     "env_TEE_AD_RETRIEVAL_KV_SERVER_ADDR": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "TEE ad retrieval KV server address"
+      }
     },
     "env_TEE_KV_SERVER_ADDR": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "TEE KV server address"
+      }
     },
     "env_AD_RETRIEVAL_KV_SERVER_ADDR": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "AD retrieval KV server address"
+      }
     },
     "env_AD_RETRIEVAL_KV_SERVER_EGRESS_TLS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "AD retrieval KV server egress TLS"
+      }
     },
     "env_AD_RETRIEVAL_TIMEOUT_MS": {
       "type": "string",
-      "defaultValue": ""
+      "metadata": {
+        "description": "AD retrieval timeout in milliseconds"
+      }
     }
   },
   "variables": {},
@@ -269,7 +357,7 @@
           {
             "name": "[parameters('containerGroupName')]",
             "properties": {
-              "image": "ispirt.azurecr.io/depa-inferencing/azure/bidding-service:nonprod-4.8.0.0",
+              "image": "ispirt.azurecr.io/depa-inferencing/azure/bidding-service:nonprod-4.3.0.0",
               "resources": {
                 "requests": {
                   "cpu": "[parameters('cpu')]",
@@ -500,9 +588,6 @@
         ],
         "osType": "Linux",
         "sku": "Confidential",
-        "confidentialComputeProperties": {
-            "ccePolicy": "cGFja2FnZSBwb2xpY3kKCmFwaV9zdm4gOj0gIjAuMTAuMCIKCm1vdW50X2RldmljZSA6PSB7ImFsbG93ZWQiOiB0cnVlfQptb3VudF9vdmVybGF5IDo9IHsiYWxsb3dlZCI6IHRydWV9CmNyZWF0ZV9jb250YWluZXIgOj0geyJhbGxvd2VkIjogdHJ1ZSwgImFsbG93X3N0ZGlvX2FjY2VzcyI6IHRydWV9CnVubW91bnRfZGV2aWNlIDo9IHsiYWxsb3dlZCI6IHRydWV9CnVubW91bnRfb3ZlcmxheSA6PSB7ImFsbG93ZWQiOiB0cnVlfQpleGVjX2luX2NvbnRhaW5lciA6PSB7ImFsbG93ZWQiOiB0cnVlfQpleGVjX2V4dGVybmFsIDo9IHsiYWxsb3dlZCI6IHRydWUsICJhbGxvd19zdGRpb19hY2Nlc3MiOiB0cnVlfQpzaHV0ZG93bl9jb250YWluZXIgOj0geyJhbGxvd2VkIjogdHJ1ZX0Kc2lnbmFsX2NvbnRhaW5lcl9wcm9jZXNzIDo9IHsiYWxsb3dlZCI6IHRydWV9CnBsYW45X21vdW50IDo9IHsiYWxsb3dlZCI6IHRydWV9CnBsYW45X3VubW91bnQgOj0geyJhbGxvd2VkIjogdHJ1ZX0KZ2V0X3Byb3BlcnRpZXMgOj0geyJhbGxvd2VkIjogdHJ1ZX0KZHVtcF9zdGFja3MgOj0geyJhbGxvd2VkIjogdHJ1ZX0KcnVudGltZV9sb2dnaW5nIDo9IHsiYWxsb3dlZCI6IHRydWV9CmxvYWRfZnJhZ21lbnQgOj0geyJhbGxvd2VkIjogdHJ1ZX0Kc2NyYXRjaF9tb3VudCA6PSB7ImFsbG93ZWQiOiB0cnVlfQpzY3JhdGNoX3VubW91bnQgOj0geyJhbGxvd2VkIjogdHJ1ZX0="
-        },        
         "restartPolicy": "Always",
         "ipAddress": {
           "type": "Public",


### PR DESCRIPTION
This PR updates the ARM templates to remove default values for all template parameters. With these templates, acipolicygen uses regex rules for all these parameters. The PR also removes allow all CCE policies from the templates, which the policy gen tool does not like. 