### PR TITLE
build from tags

### DIFF
--- a/.github/workflows/release_build_ba.yaml
+++ b/.github/workflows/release_build_ba.yaml
@@ -1,5 +1,8 @@
 name: Release Build for BA services
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release_build_kv.yaml
+++ b/.github/workflows/release_build_kv.yaml
@@ -1,5 +1,8 @@
 name: Release build for Key-Value Service
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Added options to build images from tags to the release build workflows for KV and BA. Additionally, there is the option to generate SBOMs using Syft for the images pushed to container registry.