### PR TITLE
Cleanup for KV build workflow

### DIFF
--- a/.github/workflows/release_build_kv.yaml
+++ b/.github/workflows/release_build_kv.yaml
@@ -72,6 +72,10 @@ jobs:
         echo "Push to ACR: ${{ github.event.inputs.push_to_acr }}"
         echo "Generate SBOMs: ${{ github.event.inputs.generate_sboms }}"
 
+    - name: Force cleanup before checkout
+      run: sudo rm -rf dist/ || true
+      continue-on-error: true
+
     - name: Checkout Repository
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Added a force cleanup step prior to KV code checkout. Else the code checkout's internal cleanup command will fail, especially when an earlier run fails without completing.