### PR TITLE
phased KMS deployment for ledger private endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ __pycache__
 **/.venv/
 ispirt
 uat
+prod

--- a/deployment-scripts/azure/kms/README.md
+++ b/deployment-scripts/azure/kms/README.md
@@ -4,10 +4,16 @@ This directory contains Terraform configurations for deploying the Key Managemen
 
 ## Overview
 
-The KMS deployment consists of two phases:
+The KMS deployment is split into three phases with a manual step in between. The phased design exists so that the Application Gateway can reach the Confidential Ledger over a **private endpoint** rather than the public ledger FQDN. Because Azure only exposes the ledger via a Private Link Service (PLS) that must be created out-of-band, the gateway cannot be provisioned in the same Terraform run as the ledger.
 
-1. **Main KMS Deployment** - Creates core infrastructure resources
-2. **Key Vault Networking Deployment** - Configures private endpoints and network security
+```
+Phase 1: terraform/                        --> RG, MI, VNet, Key Vault, Confidential Ledger
+Phase 2: terraform-key-vault-networking/   --> Key Vault private endpoint, disable public access
+Manual:  Create Confidential Ledger PLS    --> Produces a PLS alias (out-of-band)
+Phase 3: terraform-application-gateway/    --> Ledger private endpoint + DNS, Application Gateway
+```
+
+Each phase has its own Terraform state. Later phases discover resources from earlier phases through data sources.
 
 ## Directory Structure
 
@@ -15,31 +21,22 @@ The KMS deployment consists of two phases:
 kms/
 ├── environment/
 │   └── demo/
-│       ├── terraform/                    # Main KMS deployment
-│       │   ├── kms.tf                    # Main configuration
-│       │   ├── outputs.tf                # Output values
-│       │   └── terraform.tf              # Terraform backend configuration
-│       └── terraform-key-vault-networking/  # Networking deployment
-│           ├── main.tf                   # Networking configuration
-│           ├── data.tf                   # Data sources for existing resources
-│           ├── locals.tf                 # Local variables and VM configuration
-│           ├── outputs.tf                # Output values
-│           ├── terraform.tf              # Terraform backend configuration
-│           └── README.md                 # Detailed networking deployment guide
+│       ├── terraform/                           # Phase 1: ledger + dependencies
+│       ├── terraform-key-vault-networking/      # Phase 2: KV private endpoint
+│       ├── terraform-application-gateway/       # Phase 3: ledger PE + App Gateway
+│       └── import-state.sh                      # Rebuilds state across all phases
 ├── modules/
-│   └── kms/                              # Main KMS module
-│       ├── main.tf                       # Module implementation
-│       ├── variables.tf                  # Module input variables
-│       └── outputs.tf                    # Module outputs
-└── services/                             # Reusable service modules
-    ├── application_gateway/              # Application Gateway service
-    ├── confidential_ledger/              # Confidential Ledger service
-    ├── key_vault/                        # Key Vault service
-    ├── key_vault_networking/             # Key Vault networking (private endpoints)
-    ├── managed_identity/                 # Managed Identity service
-    ├── resource_group/                   # Resource Group service
-    ├── storage_account/                  # Storage Account service
-    └── virtual_network/                  # Virtual Network service
+│   └── kms/                                     # Phase 1 composite module
+└── services/                                    # Reusable service modules
+    ├── application_gateway/                     # Application Gateway (supports PIP reuse)
+    ├── confidential_ledger/
+    ├── key_vault/
+    ├── key_vault_networking/
+    ├── ledger_networking/                       # Ledger PE + private DNS zone
+    ├── managed_identity/
+    ├── resource_group/
+    ├── storage_account/
+    └── virtual_network/
 ```
 
 ## Prerequisites
@@ -51,9 +48,9 @@ kms/
 
 ## Deployment Process
 
-### Phase 1: Main KMS Deployment
+### Phase 1: Ledger and Dependencies
 
-Deploy the core KMS infrastructure resources:
+Deploy the Confidential Ledger along with the resource group, managed identity, virtual network, and Key Vault.
 
 ```bash
 cd environment/demo/terraform
@@ -65,105 +62,126 @@ terraform apply
 **What gets created:**
 - Resource Group
 - Managed Identity (with GitHub federated credentials)
-- Virtual Network with subnets
-- Key Vault (with public access enabled initially)
+- Virtual Network with `gateway` and `private-endpoint` subnets
+- Key Vault (with public access enabled initially; certificate issued for the ledger)
 - Confidential Ledger
-- Application Gateway
 
-### Phase 2: Key Vault Networking Deployment
+No Application Gateway is created in this phase.
 
-Configure private endpoints and disable public access:
+### Phase 2: Key Vault Networking
+
+Configure the Key Vault private endpoint and disable public access:
 
 ```bash
 cd ../terraform-key-vault-networking
 terraform init
 terraform plan
 
-# Import the existing Key Vault to manage public_network_access_enabled
+# Import the existing Key Vault so Terraform can flip public_network_access_enabled
 terraform import azurerm_key_vault.disable_public_access \
   /subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.KeyVault/vaults/{vault-name}
 
-terraform plan  # Verify the import
+terraform plan   # verify the import
 terraform apply
 ```
 
 **What gets created:**
-- Private endpoint for Key Vault (in KMS VNet)
-- Private endpoint for externally provisioned VM (if configured)
-- Private DNS zone for Key Vault
-- DNS A records with IP addresses from all private endpoints
-- VNet links for DNS zone resolution
-- **Disables public network access** on Key Vault
+- Private endpoint for Key Vault in the KMS VNet
+- Optional private endpoint for an externally provisioned VM
+- Private DNS zone `privatelink.vaultcore.azure.net` with A records
+- VNet links for DNS resolution
+- Key Vault public network access is set to **Disabled**
+
+### Manual Step: Create the Confidential Ledger Private Link Service
+
+Azure does not expose a Confidential Ledger PLS through Terraform. After Phase 1, create the PLS out-of-band (for example, via the Azure Portal's *Networking* blade on the ledger). Approve the PLS and capture its alias, which looks like:
+
+```
+depa-inferencing-kms-demo-cin-pls.{guid}.centralindia.azure.privatelinkservice
+```
+
+Record the alias; Phase 3 will not plan without it.
+
+### Phase 3: Application Gateway
+
+Set the PLS alias in `environment/demo/terraform-application-gateway/locals.tf`:
+
+```hcl
+ledger_private_link_service_alias = "depa-inferencing-kms-demo-cin-pls.{guid}.centralindia.azure.privatelinkservice"
+```
+
+Then deploy:
+
+```bash
+cd ../terraform-application-gateway
+terraform init
+terraform plan
+terraform apply
+```
+
+**What gets created:**
+- Private endpoint to the ledger PLS (manual connection, auto-approved on the PLS side)
+- Private DNS zone `confidential-ledger.azure.com` with an A record that overrides the ledger's public FQDN so it resolves to the private endpoint IP inside the VNet
+- VNet link for the DNS zone
+- Application Gateway (WAF_v2) with the **same** ledger FQDN as the backend pool address (now resolved privately), SSL termination from Key Vault, and the ledger TLS certificate as trusted root
+- Optionally reuses an existing public IP if `public_ip_id` is set in `locals.tf`
 
 ## Configuration
 
-### Main KMS Configuration
+Each phase's `locals.tf` carries its own environment values. Replace placeholders such as `<your_subscription_id>` and `<your_tenant_id>` before running Terraform.
 
-Edit `environment/demo/terraform/kms.tf` to configure:
-- Environment, region, and subscription details
-- SSL certificate name for Application Gateway
-- Log Analytics workspace for diagnostics
-- GitHub repository for managed identity federated credentials
+### Phase 1 (`terraform/kms.tf`)
 
-### Key Vault Networking Configuration
+- Environment, region, subscription, tenant
+- GitHub repository and branch for managed identity federated credentials
+- Certificate name issued in Key Vault for the ledger
 
-Edit `environment/demo/terraform-key-vault-networking/locals.tf` to configure:
+### Phase 2 (`terraform-key-vault-networking/locals.tf`)
 
-#### VM Private Endpoint (Optional)
+- Key Vault name (from Phase 1)
+- Optional VM VNet configuration for an additional private endpoint
+- Additional VNet IDs to link to the private DNS zone (without creating extra endpoints)
 
-If you have an externally provisioned VM that needs to access the Key Vault:
+### Phase 3 (`terraform-application-gateway/locals.tf`)
 
-```hcl
-# VM VNet configuration for additional private endpoint
-vm_vnet_resource_group_name = "your-vm-resource-group"
-vm_vnet_name                = "your-vm-vnet-name"
-vm_subnet_name              = "your-subnet-name"  # Subnet for private endpoint
-```
+- `ledger_private_link_service_alias` — **required**, from the manual step
+- `ssl_certificate_name`, Key Vault name, managed identity name (from Phase 1)
+- Log Analytics workspace for gateway diagnostics
+- `allowed_hostname` for Host header validation
+- Optional `public_ip_id` to reuse an existing public IP (preserves DNS-configured addresses)
 
-**Important Notes:**
-- The VM VNet should **NOT** be listed in `additional_virtual_network_ids` if you're creating a private endpoint for it
-- The subnet must exist in the VM's VNet and be delegated for private endpoints
-- The private endpoint will be created in the specified subnet
+## State Migration and Recovery
 
-#### Additional VNet Links (Optional)
+The repository includes [environment/demo/import-state.sh](environment/demo/import-state.sh) for rebuilding Terraform state from an existing Azure deployment. The script:
 
-To link the private DNS zone to other VNets (without creating private endpoints):
+- Auto-discovers the managed identity principal ID and the caller's principal ID
+- Auto-discovers role assignment IDs for the create-only role assignments
+- Imports resources into the correct state for each phase (Phase 1, Phase 2, Phase 3)
 
-```hcl
-additional_virtual_network_ids = [
-  "/subscriptions/.../resourceGroups/.../providers/Microsoft.Network/virtualNetworks/other-vnet"
-]
-```
+Run it from a directory where `az account show` resolves to the target subscription. After running, `terraform plan` in each phase should report no drift (or only expected changes).
 
 ## Key Components
 
 ### Key Vault
-- Stores SSL certificates and secrets
-- Initially created with public access enabled
-- Public access is disabled in Phase 2 after private endpoints are configured
+- Stores SSL certificates and the ledger member certificate
+- Phase 1 creates it with public access enabled so certificate issuance works
+- Phase 2 replaces public access with a private endpoint
 - Uses RBAC for authorization
 
 ### Confidential Ledger
-- Provides tamper-proof audit logging
-- Backed by Azure Key Vault for certificate management
-- Accessible via Application Gateway
+- Tamper-proof audit log, Azure AD-authenticated
+- Phase 1 provisions it; Phase 3 wires it behind a private endpoint
+- Phase 3 fetches the ledger's TLS certificate via the Azure identity service and installs it as the gateway's trusted root
 
 ### Application Gateway
-- Provides public-facing HTTPS endpoint
-- Terminates SSL using certificates from Key Vault
-- Routes traffic to Confidential Ledger backend
-- Uses private endpoint to access Key Vault for certificate retrieval
+- WAF_v2, public HTTPS frontend, SSL terminated using a Key Vault certificate
+- Backend pool uses the ledger's public FQDN; within the VNet this FQDN resolves to the private endpoint via the private DNS zone created in Phase 3
+- Accesses Key Vault through its private endpoint using the shared user-assigned managed identity
+- Supports reusing a pre-existing public IP via `public_ip_id`
 
-### Private Endpoints
-- **Main Private Endpoint**: Created in the KMS VNet for Application Gateway access
-- **VM Private Endpoint**: Optional separate endpoint for externally provisioned VMs
-- Both endpoints are registered in the same private DNS zone
-- DNS A record contains IP addresses from all endpoints for load balancing
-
-### Private DNS Zone
-- Zone: `privatelink.vaultcore.azure.net`
-- Linked to KMS VNet and VM VNet (if configured)
-- Provides DNS resolution for Key Vault private endpoints
+### Private DNS Zones
+- `privatelink.vaultcore.azure.net` (Phase 2) — Key Vault private resolution
+- `confidential-ledger.azure.com` (Phase 3) — overrides the ledger's public zone inside the KMS VNet so the public FQDN resolves to the private endpoint IP
 
 ## Network Architecture
 
@@ -171,34 +189,41 @@ additional_virtual_network_ids = [
 Internet
    │
    ▼
-Application Gateway (Public IP)
-   │
+Application Gateway (Public IP, WAF_v2)
+   │  backend = ledger FQDN (resolved privately via DNS override)
    ▼
-Confidential Ledger (Private)
+Ledger Private Endpoint ──► Confidential Ledger (via PLS)
    │
-   │
-   ├─► Key Vault (via Private Endpoint in KMS VNet)
-   │
-   └─► Key Vault (via Private Endpoint in VM VNet) ──► Externally Provisioned VM
+Gateway ──► Key Vault Private Endpoint ──► Key Vault (public access disabled)
 ```
 
 ## Troubleshooting
 
+### Phase 3 plan fails with an empty `request_message`
+
+The ledger private endpoint uses `is_manual_connection = true` and therefore requires a non-empty `request_message`. The `services/ledger_networking` module sets this, so this error typically means a stale module version is cached — re-run `terraform init -upgrade`.
+
+### Phase 3 errors with "Public IP cannot be changed"
+
+Azure does not allow swapping the frontend public IP of an existing Application Gateway via update. Either destroy and recreate the gateway (downtime) or rename the existing public IP in Azure to match the name Terraform expects and re-run `terraform apply`.
+
+### Role assignment "doesn't support update"
+
+Azure role assignments are create-only. If `terraform plan` shows an update on an imported role assignment, confirm the attributes on the resource match reality (e.g., no `skip_service_principal_aad_check` drift) and remove any immutable attribute from configuration.
+
 ### Duplicate DNS Zone Link Error
 
-If you encounter an error about a private DNS zone already being linked to a VNet:
+If a private DNS zone is already linked to a VNet:
 
-1. Check if the VNet is listed in both `additional_virtual_network_ids` and has a private endpoint configured
+1. Check whether the VNet is listed in both `additional_virtual_network_ids` and has a private endpoint configured
 2. Remove the VNet from `additional_virtual_network_ids` if a private endpoint is being created
-3. If a link already exists, you may need to import it or remove it manually:
+3. Import or remove the existing link manually:
 
 ```bash
-# List existing DNS zone links
 az network private-dns link vnet list \
   --resource-group {rg-name} \
   --zone-name privatelink.vaultcore.azure.net
 
-# Remove duplicate link if needed
 az network private-dns link vnet delete \
   --resource-group {rg-name} \
   --zone-name privatelink.vaultcore.azure.net \
@@ -207,14 +232,10 @@ az network private-dns link vnet delete \
 
 ### Key Vault Import Issues
 
-If the Key Vault import fails, ensure:
-- The Key Vault resource ID is correct
-- You have appropriate permissions
-- The Key Vault exists from Phase 1 deployment
+If the Key Vault import fails, ensure the Key Vault resource ID is correct, you have appropriate permissions, and Phase 1 has completed.
 
 ### VM Cannot Access Key Vault
 
-If the externally provisioned VM cannot access Key Vault:
 1. Verify the private endpoint is created in the correct subnet
 2. Check that the DNS zone is linked to the VM's VNet
 3. Ensure the VM's subnet allows outbound traffic to the private endpoint
@@ -222,29 +243,36 @@ If the externally provisioned VM cannot access Key Vault:
 
 ## Outputs
 
-### Main KMS Deployment
+### Phase 1 (`terraform/`)
 - Resource group name and ID
-- Key Vault URI and ID
-- Confidential Ledger endpoint
-- Application Gateway public IP
+- Key Vault name, URI, and ID
+- Confidential Ledger name and endpoint
 - Managed Identity principal ID
+- Virtual Network name and gateway/private-endpoint subnet IDs
 
-### Key Vault Networking Deployment
+### Phase 2 (`terraform-key-vault-networking/`)
 - Private DNS zone ID and name
 - Main private endpoint ID
 - VM private endpoint ID (if configured)
 
+### Phase 3 (`terraform-application-gateway/`)
+- Application Gateway endpoint and public IP
+- Ledger private endpoint ID
+- Ledger private DNS zone ID and name
+
 ## Security Considerations
 
-- Key Vault public access is disabled after private endpoints are configured
+- Key Vault public access is disabled after Phase 2
 - All Key Vault access goes through private endpoints
+- Ledger access from the Application Gateway stays inside the VNet (Phase 3)
 - Network ACLs are set to deny by default (Azure Services bypass enabled)
-- Application Gateway uses managed identity to access Key Vault
-- Confidential Ledger uses managed identity for authentication
+- Application Gateway uses a user-assigned managed identity to access Key Vault
+- Confidential Ledger uses the same managed identity for AAD-based authentication
 
 ## Additional Resources
 
-- [Key Vault Networking README](environment/demo/terraform-key-vault-networking/README.md) - Detailed guide for networking deployment
+- [Key Vault Networking README](environment/demo/terraform-key-vault-networking/README.md) — Detailed guide for Phase 2
 - [Azure Key Vault Documentation](https://docs.microsoft.com/azure/key-vault/)
 - [Azure Private Endpoints](https://docs.microsoft.com/azure/private-link/private-endpoint-overview)
+- [Azure Private Link Service](https://docs.microsoft.com/azure/private-link/private-link-service-overview)
 - [Confidential Ledger Documentation](https://docs.microsoft.com/azure/confidential-ledger/)

--- a/deployment-scripts/azure/kms/environment/demo/import-state.sh
+++ b/deployment-scripts/azure/kms/environment/demo/import-state.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# Copyright (c) iSPIRT.
+# Licensed under the Apache License, Version 2.0.
+#
+# Import existing Azure resources into Terraform state for the phased KMS deployment.
+#
+# Prerequisites:
+#   - az login (authenticated to the correct subscription)
+#   - terraform init has been run in each deployment directory
+#
+# Usage:
+#   1. Fill in SUBSCRIPTION_ID and TENANT_ID below.
+#   2. Run: bash import-state.sh
+#
+# The script auto-discovers MI_PRINCIPAL_ID and ADMIN_PRINCIPAL_ID from Azure.
+#
+# The script is idempotent — re-running it will fail harmlessly on already-imported resources.
+
+set -euo pipefail
+
+# ============================================================================
+# CONFIGURATION — Fill these in before running
+# ============================================================================
+
+SUBSCRIPTION_ID="<your_subscription_id>"
+TENANT_ID="<your_tenant_id>"
+
+# Resource names (these match the naming convention in the Terraform code)
+ENVIRONMENT="prod"
+REGION_SHORT="cin"
+RG_NAME="depa-inferencing-kms-${ENVIRONMENT}-${REGION_SHORT}-rg"
+MI_NAME="depa-inferencing-kms-${REGION_SHORT}-mi"
+VNET_NAME="depa-inferencing-kms-${ENVIRONMENT}-${REGION_SHORT}-vnet"
+KV_NAME="depa-inferencing-${REGION_SHORT}-kv"
+CERT_NAME="depa-inferencing-kms-${ENVIRONMENT}-${REGION_SHORT}-member-cert"
+LEDGER_NAME="depa-inferencing-kms-${ENVIRONMENT}-${REGION_SHORT}"
+AGW_NAME="depa-inferencing-kms-${ENVIRONMENT}-${REGION_SHORT}-agw"
+
+# Principal IDs for Key Vault role assignments (auto-discovered)
+MI_PRINCIPAL_ID=$(az identity show --name "$MI_NAME" --resource-group "$RG_NAME" --query principalId -o tsv)
+echo "Discovered MI_PRINCIPAL_ID: ${MI_PRINCIPAL_ID}"
+
+# The admin principal ID — the currently signed-in user/SP.
+# This matches the Terraform default: data.azurerm_client_config.current.object_id
+ADMIN_PRINCIPAL_ID=$(az ad signed-in-user show --query id -o tsv 2>/dev/null \
+  || az account show --query "user.name" -o tsv | xargs -I{} az ad sp show --id {} --query id -o tsv 2>/dev/null \
+  || { echo "ERROR: Could not determine admin principal ID. Set ADMIN_PRINCIPAL_ID manually."; exit 1; })
+echo "Discovered ADMIN_PRINCIPAL_ID: ${ADMIN_PRINCIPAL_ID}"
+
+# VM VNet configuration (for key-vault-networking)
+VM_VNET_RG="depa-inferencing-prod"
+VM_VNET_NAME="vnet-depainf-cicd"
+VM_SUBNET_NAME="snet-depainf-cicd"
+
+# Diagnostics workspace name (used in app gateway diagnostic setting name)
+DIAGNOSTICS_SETTING_NAME="${AGW_NAME}-diagnostics"
+
+# ============================================================================
+# Helper
+# ============================================================================
+
+SUB_PREFIX="/subscriptions/${SUBSCRIPTION_ID}"
+RG_PREFIX="${SUB_PREFIX}/resourceGroups/${RG_NAME}"
+
+import() {
+  local dir="$1"
+  local addr="$2"
+  local id="$3"
+  echo "  Importing: ${addr}"
+  (cd "$dir" && terraform import "$addr" "$id") || echo "  WARNING: import failed for ${addr} (may already exist in state)"
+}
+
+# ============================================================================
+# PHASE 1: terraform/
+# Resources: RG, Managed Identity, Federated Credential, Role Assignment,
+#            VNet, DDoS Plan, Subnets, Key Vault, KV Role Assignments,
+#            KV Certificate, Confidential Ledger
+# ============================================================================
+
+echo ""
+echo "=============================="
+echo "Phase 1: terraform/"
+echo "=============================="
+
+DIR="terraform"
+(cd "$DIR" && terraform init)
+
+# Resource Group
+import "$DIR" \
+  'module.kms.module.resource_group.azurerm_resource_group.this' \
+  "${RG_PREFIX}"
+
+# Managed Identity
+import "$DIR" \
+  'module.kms.module.managed_identity.azurerm_user_assigned_identity.this' \
+  "${RG_PREFIX}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_NAME}"
+
+# Federated Identity Credential (for GitHub Actions)
+import "$DIR" \
+  'module.kms.module.managed_identity.azurerm_federated_identity_credential.github_actions[0]' \
+  "${RG_PREFIX}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_NAME}/federatedIdentityCredentials/${MI_NAME}-github-actions"
+
+# Role Assignment: Managed Identity -> RG Contributor
+RG_CONTRIBUTOR_ID=$(az role assignment list --scope "${RG_PREFIX}" --assignee "${MI_PRINCIPAL_ID}" --role "Contributor" --query "[0].id" -o tsv)
+if [ -n "$RG_CONTRIBUTOR_ID" ]; then
+  import "$DIR" \
+    'module.kms.azurerm_role_assignment.managed_identity_rg_contributor' \
+    "${RG_CONTRIBUTOR_ID}"
+else
+  echo "  WARNING: Could not find RG Contributor role assignment for MI. Skipping."
+fi
+
+# DDoS Protection Plan
+import "$DIR" \
+  'module.kms.module.virtual_network.azurerm_network_ddos_protection_plan.this' \
+  "${RG_PREFIX}/providers/Microsoft.Network/ddosProtectionPlans/${VNET_NAME}-ddos-plan"
+
+# Virtual Network
+import "$DIR" \
+  'module.kms.module.virtual_network.azurerm_virtual_network.this' \
+  "${RG_PREFIX}/providers/Microsoft.Network/virtualNetworks/${VNET_NAME}"
+
+# Gateway Subnet
+import "$DIR" \
+  'module.kms.module.virtual_network.azurerm_subnet.gateway' \
+  "${RG_PREFIX}/providers/Microsoft.Network/virtualNetworks/${VNET_NAME}/subnets/${VNET_NAME}-gateway-subnet"
+
+# Private Endpoint Subnet
+import "$DIR" \
+  'module.kms.module.virtual_network.azurerm_subnet.private_endpoint' \
+  "${RG_PREFIX}/providers/Microsoft.Network/virtualNetworks/${VNET_NAME}/subnets/${VNET_NAME}-private-endpoint-subnet"
+
+# Key Vault
+import "$DIR" \
+  'module.kms.module.key_vault.azurerm_key_vault.this' \
+  "${RG_PREFIX}/providers/Microsoft.KeyVault/vaults/${KV_NAME}"
+
+# Key Vault Role Assignments (auto-discovered)
+KV_SCOPE="${RG_PREFIX}/providers/Microsoft.KeyVault/vaults/${KV_NAME}"
+
+import_kv_role() {
+  local addr="$1"
+  local principal="$2"
+  local role="$3"
+  local role_id
+  role_id=$(az role assignment list --scope "${KV_SCOPE}" --assignee "${principal}" --role "${role}" --query "[0].id" -o tsv)
+  if [ -n "$role_id" ]; then
+    import "$DIR" "$addr" "$role_id"
+  else
+    echo "  WARNING: Could not find '${role}' assignment for principal ${principal}. Skipping."
+  fi
+}
+
+import_kv_role 'module.kms.module.key_vault.azurerm_role_assignment.admin[0]'               "$ADMIN_PRINCIPAL_ID" "Key Vault Administrator"
+import_kv_role 'module.kms.module.key_vault.azurerm_role_assignment.crypto_user[0]'          "$MI_PRINCIPAL_ID"    "Key Vault Crypto User"
+import_kv_role 'module.kms.module.key_vault.azurerm_role_assignment.crypto_officer[0]'       "$MI_PRINCIPAL_ID"    "Key Vault Crypto Officer"
+import_kv_role 'module.kms.module.key_vault.azurerm_role_assignment.certificates_officer[0]' "$MI_PRINCIPAL_ID"    "Key Vault Certificates Officer"
+import_kv_role 'module.kms.module.key_vault.azurerm_role_assignment.secrets_user[0]'         "$MI_PRINCIPAL_ID"    "Key Vault Secrets User"
+
+# Key Vault Certificate (needs versioned URL)
+CERT_VERSION=$(az keyvault certificate show --vault-name "${KV_NAME}" --name "${CERT_NAME}" --query "id" -o tsv)
+if [ -n "$CERT_VERSION" ]; then
+  import "$DIR" \
+    'module.kms.module.key_vault.azurerm_key_vault_certificate.member' \
+    "${CERT_VERSION}"
+else
+  echo "  WARNING: Could not find certificate ${CERT_NAME} in ${KV_NAME}. Skipping."
+fi
+
+# Confidential Ledger
+import "$DIR" \
+  'module.kms.module.confidential_ledger.azurerm_confidential_ledger.this' \
+  "${RG_PREFIX}/providers/Microsoft.ConfidentialLedger/ledgers/${LEDGER_NAME}"
+
+echo ""
+echo "Phase 1 import complete. Run 'cd ${DIR} && terraform plan' to verify."
+
+# ============================================================================
+# PHASE 2: terraform-key-vault-networking/
+# Resources: KV Private DNS Zone, VNet Links, Private Endpoints, A Record,
+#            Key Vault (disable_public_access)
+# ============================================================================
+
+echo ""
+echo "=============================="
+echo "Phase 2: terraform-key-vault-networking/"
+echo "=============================="
+
+DIR="terraform-key-vault-networking"
+(cd "$DIR" && terraform init)
+
+# Private DNS Zone
+import "$DIR" \
+  'module.key_vault_networking.azurerm_private_dns_zone.key_vault' \
+  "${RG_PREFIX}/providers/Microsoft.Network/privateDnsZones/privatelink.vaultcore.azure.net"
+
+# VNet Link (KMS VNet)
+import "$DIR" \
+  'module.key_vault_networking.azurerm_private_dns_zone_virtual_network_link.key_vault' \
+  "${RG_PREFIX}/providers/Microsoft.Network/privateDnsZones/privatelink.vaultcore.azure.net/virtualNetworkLinks/${KV_NAME}-vnet-link"
+
+# VNet Link (VM VNet)
+import "$DIR" \
+  'module.key_vault_networking.azurerm_private_dns_zone_virtual_network_link.key_vault_vm[0]' \
+  "${RG_PREFIX}/providers/Microsoft.Network/privateDnsZones/privatelink.vaultcore.azure.net/virtualNetworkLinks/${KV_NAME}-vnet-link-vm"
+
+# Private Endpoint (KMS VNet)
+import "$DIR" \
+  'module.key_vault_networking.azurerm_private_endpoint.key_vault' \
+  "${RG_PREFIX}/providers/Microsoft.Network/privateEndpoints/${KV_NAME}-pe"
+
+# Private Endpoint (VM VNet)
+import "$DIR" \
+  'module.key_vault_networking.azurerm_private_endpoint.key_vault_vm[0]' \
+  "${RG_PREFIX}/providers/Microsoft.Network/privateEndpoints/${KV_NAME}-pe-vm"
+
+# DNS A Record
+import "$DIR" \
+  'module.key_vault_networking.azurerm_private_dns_a_record.key_vault' \
+  "${RG_PREFIX}/providers/Microsoft.Network/privateDnsZones/privatelink.vaultcore.azure.net/A/${KV_NAME}"
+
+# Key Vault (disable_public_access) — the imported KV resource
+import "$DIR" \
+  'azurerm_key_vault.disable_public_access' \
+  "${RG_PREFIX}/providers/Microsoft.KeyVault/vaults/${KV_NAME}"
+
+echo ""
+echo "Phase 2 import complete. Run 'cd ${DIR} && terraform plan' to verify."
+
+# ============================================================================
+# PHASE 3: terraform-application-gateway/
+# Resources: Application Gateway, Public IP, WAF Policy, Diagnostic Setting
+#            + Ledger Networking (PE, DNS Zone, VNet Link, A Record)
+# ============================================================================
+
+echo ""
+echo "=============================="
+echo "Phase 3: terraform-application-gateway/"
+echo "=============================="
+
+DIR="terraform-application-gateway"
+(cd "$DIR" && terraform init)
+
+# Application Gateway
+import "$DIR" \
+  'module.application_gateway.azurerm_application_gateway.this' \
+  "${RG_PREFIX}/providers/Microsoft.Network/applicationGateways/${AGW_NAME}"
+
+# Public IP
+import "$DIR" \
+  'module.application_gateway.azurerm_public_ip.gateway' \
+  "${RG_PREFIX}/providers/Microsoft.Network/publicIPAddresses/${AGW_NAME}-pip"
+
+# WAF Policy
+import "$DIR" \
+  'module.application_gateway.azurerm_web_application_firewall_policy.this' \
+  "${RG_PREFIX}/providers/Microsoft.Network/applicationGatewayWebApplicationFirewallPolicies/${AGW_NAME}-waf-policy"
+
+# Diagnostic Setting (if diagnostics were configured)
+import "$DIR" \
+  'module.application_gateway.azurerm_monitor_diagnostic_setting.application_gateway[0]' \
+  "${RG_PREFIX}/providers/Microsoft.Network/applicationGateways/${AGW_NAME}|${DIAGNOSTICS_SETTING_NAME}"
+
+# Ledger Networking resources — these are NEW and may not exist yet.
+# Only import these if they were already created in Azure.
+echo ""
+echo "  NOTE: Ledger networking resources (PE, DNS zone, A record, VNet link) are new."
+echo "  If they don't exist yet in Azure, skip these imports — they will be created by terraform apply."
+echo ""
+echo "  If they do exist, import them:"
+echo "    cd ${DIR} && terraform import 'module.ledger_networking.azurerm_private_dns_zone.ledger' '${RG_PREFIX}/providers/Microsoft.Network/privateDnsZones/confidential-ledger.azure.com'"
+echo "    cd ${DIR} && terraform import 'module.ledger_networking.azurerm_private_dns_zone_virtual_network_link.ledger' '${RG_PREFIX}/providers/Microsoft.Network/privateDnsZones/confidential-ledger.azure.com/virtualNetworkLinks/${LEDGER_NAME}-vnet-link'"
+echo "    cd ${DIR} && terraform import 'module.ledger_networking.azurerm_private_endpoint.ledger' '${RG_PREFIX}/providers/Microsoft.Network/privateEndpoints/${LEDGER_NAME}-pe'"
+echo "    cd ${DIR} && terraform import 'module.ledger_networking.azurerm_private_dns_a_record.ledger' '${RG_PREFIX}/providers/Microsoft.Network/privateDnsZones/confidential-ledger.azure.com/A/${LEDGER_NAME}'"
+
+echo ""
+echo "Phase 3 import complete. Run 'cd ${DIR} && terraform plan' to verify."
+
+echo ""
+echo "=============================="
+echo "All imports done."
+echo "Run 'terraform plan' in each directory to verify no unexpected changes."
+echo "=============================="

--- a/deployment-scripts/azure/kms/environment/demo/terraform-application-gateway/data.tf
+++ b/deployment-scripts/azure/kms/environment/demo/terraform-application-gateway/data.tf
@@ -1,0 +1,43 @@
+# Copyright (c) iSPIRT.
+# Licensed under the Apache License, Version 2.0.
+
+# Discover existing resources created by the Phase 1 (terraform/) deployment.
+
+data "azurerm_resource_group" "kms" {
+  name = local.resource_group_name
+}
+
+data "azurerm_virtual_network" "kms" {
+  name                = local.virtual_network_name
+  resource_group_name = local.resource_group_name
+}
+
+# Gateway subnet for the Application Gateway
+data "azurerm_subnet" "gateway" {
+  name                 = "${local.virtual_network_name}-gateway-subnet"
+  virtual_network_name = data.azurerm_virtual_network.kms.name
+  resource_group_name  = local.resource_group_name
+}
+
+# Private endpoint subnet for the Ledger private endpoint
+data "azurerm_subnet" "private_endpoint" {
+  name                 = "${local.virtual_network_name}-private-endpoint-subnet"
+  virtual_network_name = data.azurerm_virtual_network.kms.name
+  resource_group_name  = local.resource_group_name
+}
+
+data "azurerm_key_vault" "kms" {
+  name                = local.key_vault_name
+  resource_group_name = local.resource_group_name
+}
+
+data "azurerm_user_assigned_identity" "kms" {
+  name                = local.managed_identity_name
+  resource_group_name = local.resource_group_name
+}
+
+# Fetch the Confidential Ledger's TLS certificate from Azure's identity service.
+# This is the same mechanism used by services/confidential_ledger/main.tf.
+data "http" "ledger_identity" {
+  url = "https://identity.confidential-ledger.core.azure.com/ledgerIdentity/${local.ledger_name}"
+}

--- a/deployment-scripts/azure/kms/environment/demo/terraform-application-gateway/locals.tf
+++ b/deployment-scripts/azure/kms/environment/demo/terraform-application-gateway/locals.tf
@@ -1,0 +1,33 @@
+# Copyright (c) iSPIRT.
+# Licensed under the Apache License, Version 2.0.
+
+locals {
+  environment  = "prod"
+  operator     = "tf"
+  region       = "centralindia"
+  region_short = "cin"
+
+  subscription_id = "<your_subscription_id>"
+  tenant_id       = "<your_tenant_id>"
+
+  resource_group_name      = "depa-inferencing-kms-${local.environment}-${local.region_short}-rg"
+  key_vault_name           = "depa-inferencing-${local.region_short}-kv"
+  virtual_network_name     = "depa-inferencing-kms-${local.environment}-${local.region_short}-vnet"
+  application_gateway_name = "depa-inferencing-kms-${local.environment}-${local.region_short}-agw"
+  managed_identity_name    = "depa-inferencing-kms-${local.region_short}-mi"
+  ledger_name              = "depa-inferencing-kms-${local.environment}-${local.region_short}"
+
+  # Private Link Service alias for the Confidential Ledger.
+  # This must be filled in after the manual step of creating the PLS out-of-band.
+  # Example: depa-inferencing-kms-prod-cin-pls.bda3e1dd-05f2-4760-aab6-df4ebb5aaa90.centralindia.azure.privatelinkservice
+  ledger_private_link_service_alias = "" # REQUIRED: Fill in after manual PLS creation
+
+  ssl_certificate_name                                    = "depa-inferencing-kms-uat-cin-frontend-cert"
+  diagnostics_log_analytics_workspace_name                = "depa-inferencing-sentinel-workspace"
+  diagnostics_log_analytics_workspace_resource_group_name = "depa-inferencing-sentinel-rg"
+  allowed_hostname                                        = "depa-inferencing-kms-azure.ispirt.in"
+
+  extra_tags = {
+    Owner = "ispirt"
+  }
+}

--- a/deployment-scripts/azure/kms/environment/demo/terraform-application-gateway/main.tf
+++ b/deployment-scripts/azure/kms/environment/demo/terraform-application-gateway/main.tf
@@ -1,0 +1,63 @@
+# Copyright (c) iSPIRT.
+# Licensed under the Apache License, Version 2.0.
+
+# This deployment creates the Ledger private endpoint networking and Application Gateway.
+# It discovers existing resources created by the Phase 1 (terraform/) deployment.
+#
+# Prerequisites:
+# 1. Phase 1 (terraform/) must be deployed first.
+# 2. A Private Link Service for the Confidential Ledger must be created out-of-band.
+# 3. The PLS alias must be set in locals.tf as ledger_private_link_service_alias.
+
+locals {
+  ledger_identity_json   = jsondecode(data.http.ledger_identity.response_body)
+  ledger_tls_certificate = local.ledger_identity_json.ledgerTlsCertificate
+
+  base_tags = {
+    Environment = local.environment
+    ManagedBy   = "Terraform"
+    Workload    = "depa-inferencing-kms"
+  }
+}
+
+# Create private endpoint and DNS for the Confidential Ledger via its Private Link Service.
+# This overrides public DNS so the ledger's FQDN resolves to the private endpoint IP within the VNet.
+module "ledger_networking" {
+  source = "../../../services/ledger_networking"
+
+  name                       = local.ledger_name
+  resource_group_name        = data.azurerm_resource_group.kms.name
+  location                   = data.azurerm_resource_group.kms.location
+  private_link_service_alias = local.ledger_private_link_service_alias
+  private_endpoint_subnet_id = data.azurerm_subnet.private_endpoint.id
+  virtual_network_id         = data.azurerm_virtual_network.kms.id
+  tags                       = merge(local.base_tags, local.extra_tags)
+}
+
+# Application Gateway with the Ledger private endpoint FQDN as backend.
+# The backend address is the same FQDN as the public ledger endpoint, but within the VNet
+# it resolves to the private endpoint IP via the private DNS zone created above.
+module "application_gateway" {
+  source = "../../../services/application_gateway"
+
+  name                                                    = local.application_gateway_name
+  resource_group_name                                     = data.azurerm_resource_group.kms.name
+  location                                                = data.azurerm_resource_group.kms.location
+  subnet_id                                               = data.azurerm_subnet.gateway.id
+  backend_address                                         = module.ledger_networking.ledger_private_fqdn
+  backend_hostname                                        = local.ledger_name
+  backend_port                                            = 443
+  trusted_root_certificate                                = local.ledger_tls_certificate
+  ssl_certificate_name                                    = local.ssl_certificate_name
+  key_vault_uri                                           = data.azurerm_key_vault.kms.vault_uri
+  managed_identity_id                                     = data.azurerm_user_assigned_identity.kms.id
+  diagnostics_log_analytics_workspace_name                = local.diagnostics_log_analytics_workspace_name
+  diagnostics_log_analytics_workspace_resource_group_name = local.diagnostics_log_analytics_workspace_resource_group_name
+  tags                                                    = merge(local.base_tags, local.extra_tags)
+  health_probe_path                                       = "/node/metrics"
+  allowed_hostname                                        = local.allowed_hostname
+
+  depends_on = [
+    module.ledger_networking,
+  ]
+}

--- a/deployment-scripts/azure/kms/environment/demo/terraform-application-gateway/outputs.tf
+++ b/deployment-scripts/azure/kms/environment/demo/terraform-application-gateway/outputs.tf
@@ -1,0 +1,32 @@
+# Copyright (c) iSPIRT.
+# Licensed under the Apache License, Version 2.0.
+
+output "application_gateway_id" {
+  description = "Resource ID of the Application Gateway."
+  value       = module.application_gateway.id
+}
+
+output "application_gateway_endpoint" {
+  description = "Endpoint URL of the Application Gateway."
+  value       = module.application_gateway.endpoint
+}
+
+output "application_gateway_public_ip" {
+  description = "Public IP address of the Application Gateway."
+  value       = module.application_gateway.public_ip_address
+}
+
+output "ledger_private_endpoint_id" {
+  description = "Resource ID of the Ledger private endpoint."
+  value       = module.ledger_networking.private_endpoint_id
+}
+
+output "ledger_private_dns_zone_id" {
+  description = "Resource ID of the private DNS zone for the Confidential Ledger."
+  value       = module.ledger_networking.private_dns_zone_id
+}
+
+output "ledger_private_fqdn" {
+  description = "Private FQDN for the Confidential Ledger."
+  value       = module.ledger_networking.ledger_private_fqdn
+}

--- a/deployment-scripts/azure/kms/environment/demo/terraform-application-gateway/terraform.tf
+++ b/deployment-scripts/azure/kms/environment/demo/terraform-application-gateway/terraform.tf
@@ -1,0 +1,24 @@
+# Copyright (c) iSPIRT.
+# Licensed under the Apache License, Version 2.0.
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.54"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = "~> 3.4"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+
+  subscription_id = local.subscription_id
+  tenant_id       = local.tenant_id
+}

--- a/deployment-scripts/azure/kms/environment/demo/terraform-key-vault-networking/locals.tf
+++ b/deployment-scripts/azure/kms/environment/demo/terraform-key-vault-networking/locals.tf
@@ -7,14 +7,12 @@ locals {
   region       = "centralindia"
   region_short = "cin"
 
-  subscription_id = "2a5f1e30-b076-4cb2-9235-2036241dedf0"
-  tenant_id       = "3039a1ed-8db4-4652-a69b-9ff4e265e18d"
+  subscription_id = "<your_subscription_id>"
+  tenant_id       = "<your_tenant_id>"
 
   resource_group_name      = "depa-inferencing-kms-${local.environment}-${local.region_short}-rg"
   key_vault_name           = "depa-inferencing-${local.region_short}-kv"
   virtual_network_name     = "depa-inferencing-kms-${local.environment}-${local.region_short}-vnet"
-  application_gateway_name = "depa-inferencing-kms-${local.environment}-${local.region_short}-agw"
-
   extra_tags = {
     Owner = "ispirt"
   }

--- a/deployment-scripts/azure/kms/environment/demo/terraform-key-vault-networking/main.tf
+++ b/deployment-scripts/azure/kms/environment/demo/terraform-key-vault-networking/main.tf
@@ -72,24 +72,3 @@ resource "azurerm_key_vault" "disable_public_access" {
   ]
 }
 
-# Ensure Application Gateway uses private endpoint for Key Vault access
-# The Application Gateway's SSL certificate references Key Vault using key_vault_secret_id.
-# Once the private DNS zone is linked to the VNet, the Application Gateway will automatically
-# resolve Key Vault DNS to the private endpoint IP address.
-#
-# Note: The Application Gateway's key_vault_secret_id uses the format:
-# https://{vault-name}.vault.azure.net/secrets/{secret-name}
-# Azure's DNS resolution within the VNet will automatically use the private endpoint
-# when the private DNS zone (privatelink.vaultcore.azure.net) is linked to the VNet.
-#
-# This data source ensures the Application Gateway exists and will use the private endpoint
-# once the private DNS zone link is established.
-data "azurerm_application_gateway" "kms" {
-  name                = local.application_gateway_name
-  resource_group_name = local.resource_group_name
-
-  depends_on = [
-    module.key_vault_networking,
-  ]
-}
-

--- a/deployment-scripts/azure/kms/environment/demo/terraform-key-vault-networking/outputs.tf
+++ b/deployment-scripts/azure/kms/environment/demo/terraform-key-vault-networking/outputs.tf
@@ -16,13 +16,3 @@ output "key_vault_private_dns_zone_name" {
   value       = module.key_vault_networking.private_dns_zone_name
 }
 
-output "application_gateway_id" {
-  description = "Resource ID of the Application Gateway that will use the Key Vault private endpoint."
-  value       = data.azurerm_application_gateway.kms.id
-}
-
-output "application_gateway_name" {
-  description = "Name of the Application Gateway that will use the Key Vault private endpoint."
-  value       = data.azurerm_application_gateway.kms.name
-}
-

--- a/deployment-scripts/azure/kms/environment/demo/terraform/kms.tf
+++ b/deployment-scripts/azure/kms/environment/demo/terraform/kms.tf
@@ -7,20 +7,14 @@ locals {
   region       = "centralindia"
   region_short = "cin"
 
-  subscription_id = "2a5f1e30-b076-4cb2-9235-2036241dedf0"
-  tenant_id       = "3039a1ed-8db4-4652-a69b-9ff4e265e18d"
+  subscription_id = "<your_subscription_id>"
+  tenant_id       = "<your_tenant_id>"
 
   resource_group_name = "depa-inferencing-kms-${local.environment}-${local.region_short}-rg"
 
   extra_tags = {
     Owner = "ispirt"
   }
-
-  ssl_certificate_name                                    = "depa-inferencing-kms-prod-cin-frontend-cert" # Name of the SSL certificate in Key Vault for Application Gateway.
-  diagnostics_log_analytics_workspace_name                = "depa-inferencing-sentinel-workspace"         # Optional: Log Analytics workspace name for Application Gateway diagnostics.
-  diagnostics_log_analytics_workspace_resource_group_name = "depa-inferencing-sentinel-rg"                # Optional: Resource group that hosts the Log Analytics workspace.
-
-  allowed_hostname = "depa-inferencing-kms-azure.ispirt.in" # Allowed hostname for Application Gateway Host header validation.
 }
 
 module "kms" {
@@ -35,10 +29,6 @@ module "kms" {
   extra_tags                                              = local.extra_tags
   github_repository                                       = "iSPIRT/azure-depa-inferencing-kms"
   github_branch                                           = "main"
-  ssl_certificate_name                                    = local.ssl_certificate_name
-  diagnostics_log_analytics_workspace_name                = local.diagnostics_log_analytics_workspace_name
-  diagnostics_log_analytics_workspace_resource_group_name = local.diagnostics_log_analytics_workspace_resource_group_name
-  allowed_hostname                                         = local.allowed_hostname
-  # Note: additional_virtual_network_ids is only used in the key-vault-networking deployment, not here
+  # Note: Application Gateway is deployed separately via terraform-application-gateway/
 }
 

--- a/deployment-scripts/azure/kms/environment/demo/terraform/kms.tf
+++ b/deployment-scripts/azure/kms/environment/demo/terraform/kms.tf
@@ -12,6 +12,8 @@ locals {
 
   resource_group_name = "depa-inferencing-kms-${local.environment}-${local.region_short}-rg"
 
+  enable_ddos_protection = false
+
   extra_tags = {
     Owner = "ispirt"
   }
@@ -26,6 +28,7 @@ module "kms" {
   region                                                  = local.region
   region_short                                            = local.region_short
   resource_group_name                                     = local.resource_group_name
+  enable_ddos_protection                                  = local.enable_ddos_protection
   extra_tags                                              = local.extra_tags
   github_repository                                       = "iSPIRT/azure-depa-inferencing-kms"
   github_branch                                           = "main"

--- a/deployment-scripts/azure/kms/environment/demo/terraform/outputs.tf
+++ b/deployment-scripts/azure/kms/environment/demo/terraform/outputs.tf
@@ -41,18 +41,23 @@ output "kms_key_vault_uri" {
   value       = module.kms.key_vault_uri
 }
 
-output "kms_application_gateway_endpoint" {
-  description = "Endpoint URL of the Application Gateway."
-  value       = module.kms.application_gateway_endpoint
+output "kms_virtual_network_name" {
+  description = "Name of the KMS Virtual Network."
+  value       = module.kms.virtual_network_name
 }
 
-output "kms_application_gateway_public_ip" {
-  description = "Public IP address of the Application Gateway."
-  value       = module.kms.application_gateway_public_ip
+output "kms_gateway_subnet_id" {
+  description = "Resource ID of the Application Gateway subnet."
+  value       = module.kms.gateway_subnet_id
 }
 
-output "kms_ledger_endpoint_name" {
-  description = "Name of the Confidential Ledger endpoint."
-  value       = module.kms.ledger_endpoint_name
+output "kms_ledger_endpoint" {
+  description = "Ledger Endpoint for the Confidential Ledger."
+  value       = module.kms.ledger_endpoint
+}
+
+output "kms_confidential_ledger_name" {
+  description = "Name of the Confidential Ledger."
+  value       = module.kms.confidential_ledger_name
 }
 

--- a/deployment-scripts/azure/kms/modules/kms/main.tf
+++ b/deployment-scripts/azure/kms/modules/kms/main.tf
@@ -4,7 +4,7 @@
 locals {
   default_resource_group_name  = "depa-inferencing-kms-${var.environment}-${var.region_short}-rg"
   default_identity_name        = "depa-inferencing-kms-${var.region_short}-mi"
-  default_key_vault_name       = "depa-inferencing-uat-kv"
+  default_key_vault_name       = "depa-inferencing-${var.environment}-kv"
   default_certificate_name     = "depa-inferencing-kms-${var.environment}-${var.region_short}-member-cert"
   default_ledger_name          = "depa-inferencing-kms-${var.environment}-${var.region_short}"
   default_vnet_name            = "depa-inferencing-kms-${var.environment}-${var.region_short}-vnet"

--- a/deployment-scripts/azure/kms/modules/kms/main.tf
+++ b/deployment-scripts/azure/kms/modules/kms/main.tf
@@ -81,11 +81,12 @@ resource "azurerm_role_assignment" "managed_identity_rg_contributor" {
 }
 
 module "virtual_network" {
-  source              = "../../services/virtual_network"
-  name                = local.virtual_network_name
-  resource_group_name = module.resource_group.name
-  location            = module.resource_group.location
-  tags                = merge(local.base_tags, var.extra_tags)
+  source                 = "../../services/virtual_network"
+  name                   = local.virtual_network_name
+  resource_group_name    = module.resource_group.name
+  location               = module.resource_group.location
+  tags                   = merge(local.base_tags, var.extra_tags)
+  enable_ddos_protection = var.enable_ddos_protection
 }
 
 # Key Vault: Creates Key Vault with network ACLs and certificate

--- a/deployment-scripts/azure/kms/modules/kms/main.tf
+++ b/deployment-scripts/azure/kms/modules/kms/main.tf
@@ -4,11 +4,10 @@
 locals {
   default_resource_group_name  = "depa-inferencing-kms-${var.environment}-${var.region_short}-rg"
   default_identity_name        = "depa-inferencing-kms-${var.region_short}-mi"
-  default_key_vault_name       = "depa-inferencing-${var.region_short}-kv"
+  default_key_vault_name       = "depa-inferencing-uat-kv"
   default_certificate_name     = "depa-inferencing-kms-${var.environment}-${var.region_short}-member-cert"
   default_ledger_name          = "depa-inferencing-kms-${var.environment}-${var.region_short}"
   default_vnet_name            = "depa-inferencing-kms-${var.environment}-${var.region_short}-vnet"
-  default_app_gateway_name     = "depa-inferencing-kms-${var.environment}-${var.region_short}-agw"
 
   resource_group_name = (
     var.resource_group_name != "" ?
@@ -46,12 +45,6 @@ locals {
     local.default_vnet_name
   )
 
-  application_gateway_name = (
-    var.application_gateway_name != "" ?
-    var.application_gateway_name :
-    local.default_app_gateway_name
-  )
-
   base_tags = {
     Environment = var.environment
     ManagedBy   = "Terraform"
@@ -77,10 +70,9 @@ module "managed_identity" {
 }
 
 resource "azurerm_role_assignment" "managed_identity_rg_contributor" {
-  principal_id                     = module.managed_identity.principal_id
-  role_definition_name             = "Contributor"
-  scope                            = module.resource_group.id
-  skip_service_principal_aad_check = true
+  principal_id         = module.managed_identity.principal_id
+  role_definition_name = "Contributor"
+  scope                = module.resource_group.id
 
   depends_on = [
     module.managed_identity,
@@ -132,27 +124,4 @@ module "confidential_ledger" {
   ]
 }
 
-module "application_gateway" {
-  source                                                  = "../../services/application_gateway"
-  name                                                    = local.application_gateway_name
-  resource_group_name                                     = module.resource_group.name
-  location                                                = module.resource_group.location
-  subnet_id                                               = module.virtual_network.gateway_subnet_id
-  backend_address                                         = replace(module.confidential_ledger.ledger_endpoint, "https://", "")
-  backend_hostname                                        = module.confidential_ledger.name
-  backend_port                                            = 443
-  trusted_root_certificate                                = module.confidential_ledger.ledger_tls_certificate
-  ssl_certificate_name                                    = var.ssl_certificate_name
-  key_vault_uri                                           = module.key_vault.uri
-  managed_identity_id                                     = module.managed_identity.id
-  diagnostics_log_analytics_workspace_name                = var.diagnostics_log_analytics_workspace_name
-  diagnostics_log_analytics_workspace_resource_group_name = var.diagnostics_log_analytics_workspace_resource_group_name
-  tags                                                    = merge(local.base_tags, var.extra_tags)
-  health_probe_path                                       = "/node/metrics"
-  allowed_hostname                                        = var.allowed_hostname
-  depends_on = [
-    module.virtual_network,
-    module.confidential_ledger,
-  ]
-}
 

--- a/deployment-scripts/azure/kms/modules/kms/outputs.tf
+++ b/deployment-scripts/azure/kms/modules/kms/outputs.tf
@@ -46,18 +46,23 @@ output "key_vault_uri" {
   value       = module.key_vault.uri
 }
 
-output "application_gateway_endpoint" {
-  description = "Endpoint URL of the Application Gateway."
-  value       = module.application_gateway.endpoint
+output "virtual_network_name" {
+  description = "Name of the KMS Virtual Network."
+  value       = module.virtual_network.name
 }
 
-output "application_gateway_public_ip" {
-  description = "Public IP address of the Application Gateway."
-  value       = module.application_gateway.public_ip_address
+output "gateway_subnet_id" {
+  description = "Resource ID of the Application Gateway subnet."
+  value       = module.virtual_network.gateway_subnet_id
 }
 
-output "ledger_endpoint_name" {
-  description = "Name of the Confidential Ledger endpoint."
+output "ledger_endpoint" {
+  description = "Ledger Endpoint for the Confidential Ledger."
+  value       = module.confidential_ledger.ledger_endpoint
+}
+
+output "confidential_ledger_name" {
+  description = "Name of the Confidential Ledger."
   value       = module.confidential_ledger.name
 }
 

--- a/deployment-scripts/azure/kms/modules/kms/variables.tf
+++ b/deployment-scripts/azure/kms/modules/kms/variables.tf
@@ -80,4 +80,10 @@ variable "extra_tags" {
   default     = {}
 }
 
+variable "enable_ddos_protection" {
+  type        = bool
+  description = "Whether to create a DDoS Protection Plan and attach it to the Virtual Network."
+  default     = false
+}
+
 

--- a/deployment-scripts/azure/kms/modules/kms/variables.tf
+++ b/deployment-scripts/azure/kms/modules/kms/variables.tf
@@ -56,12 +56,6 @@ variable "ledger_name" {
   default     = ""
 }
 
-variable "application_gateway_name" {
-  type        = string
-  description = "Optional explicit name for the application gateway. Defaults to a convention-based value when empty."
-  default     = ""
-}
-
 variable "virtual_network_name" {
   type        = string
   description = "Optional explicit name for the virtual network. Defaults to a convention-based value when empty."
@@ -80,37 +74,10 @@ variable "github_branch" {
   default     = ""
 }
 
-variable "ssl_certificate_name" {
-  type        = string
-  description = "Name of the SSL certificate in Key Vault for Application Gateway."
-}
-
-variable "diagnostics_log_analytics_workspace_name" {
-  type        = string
-  description = "Log Analytics workspace name for Application Gateway diagnostics. If empty, diagnostics are disabled."
-  default     = ""
-}
-
-variable "diagnostics_log_analytics_workspace_resource_group_name" {
-  type        = string
-  description = "Resource group name of the Log Analytics workspace for Application Gateway diagnostics. If empty, defaults to the Application Gateway resource group."
-  default     = ""
-}
-
 variable "extra_tags" {
   type        = map(string)
   description = "Additional tags to append to the default KMS tag set."
   default     = {}
 }
 
-variable "additional_virtual_network_ids" {
-  type        = list(string)
-  description = "List of additional Virtual Network IDs to link the Key Vault private DNS zone to. This allows VMs in other VNets to access the Key Vault via private endpoint. NOTE: This variable is NOT used in the main KMS deployment - it is only used in the separate key-vault-networking deployment."
-  default     = []
-}
-
-variable "allowed_hostname" {
-  type        = string
-  description = "Allowed hostname for Application Gateway Host header validation. Requests with Host headers not matching this hostname will be blocked by WAF."
-}
 

--- a/deployment-scripts/azure/kms/services/application_gateway/main.tf
+++ b/deployment-scripts/azure/kms/services/application_gateway/main.tf
@@ -18,6 +18,7 @@ locals {
 }
 
 resource "azurerm_public_ip" "gateway" {
+  count               = var.public_ip_id == "" ? 1 : 0
   name                = "${var.name}-pip"
   resource_group_name = var.resource_group_name
   location            = var.location
@@ -25,6 +26,18 @@ resource "azurerm_public_ip" "gateway" {
   sku                 = "Standard"
   zones               = var.zones
   tags                = var.tags
+}
+
+data "azurerm_public_ip" "existing" {
+  count               = var.public_ip_id != "" ? 1 : 0
+  name                = split("/", var.public_ip_id)[8]
+  resource_group_name = split("/", var.public_ip_id)[4]
+}
+
+locals {
+  public_ip_id      = var.public_ip_id != "" ? var.public_ip_id : azurerm_public_ip.gateway[0].id
+  public_ip_address = var.public_ip_id != "" ? data.azurerm_public_ip.existing[0].ip_address : azurerm_public_ip.gateway[0].ip_address
+  public_ip_fqdn    = var.public_ip_id != "" ? data.azurerm_public_ip.existing[0].fqdn : azurerm_public_ip.gateway[0].fqdn
 }
 
 resource "azurerm_web_application_firewall_policy" "this" {
@@ -75,7 +88,6 @@ resource "azurerm_application_gateway" "this" {
   location            = var.location
   zones               = var.zones
   tags                = var.tags
-  enable_http2        = true
 
   identity {
     type         = "UserAssigned"
@@ -102,7 +114,7 @@ resource "azurerm_application_gateway" "this" {
 
   frontend_ip_configuration {
     name                 = "frontend-ip"
-    public_ip_address_id = azurerm_public_ip.gateway.id
+    public_ip_address_id = local.public_ip_id
   }
 
   backend_address_pool {

--- a/deployment-scripts/azure/kms/services/application_gateway/outputs.tf
+++ b/deployment-scripts/azure/kms/services/application_gateway/outputs.tf
@@ -13,24 +13,24 @@ output "name" {
 
 output "public_ip_address" {
   description = "Public IP address of the Application Gateway."
-  value       = azurerm_public_ip.gateway.ip_address
+  value       = local.public_ip_address
 }
 
 output "public_ip_id" {
   description = "Resource ID of the public IP address."
-  value       = azurerm_public_ip.gateway.id
+  value       = local.public_ip_id
 }
 
 output "fqdn" {
   description = "FQDN of the Application Gateway."
-  value       = azurerm_public_ip.gateway.fqdn
+  value       = local.public_ip_fqdn
 }
 
 output "endpoint" {
   description = "Endpoint URL of the Application Gateway (using FQDN if available, otherwise IP address)."
   value = coalesce(
-    azurerm_public_ip.gateway.fqdn != null && azurerm_public_ip.gateway.fqdn != "" ? "http://${azurerm_public_ip.gateway.fqdn}" : null,
-    "http://${azurerm_public_ip.gateway.ip_address}"
+    local.public_ip_fqdn != null && local.public_ip_fqdn != "" ? "http://${local.public_ip_fqdn}" : null,
+    "http://${local.public_ip_address}"
   )
 }
 

--- a/deployment-scripts/azure/kms/services/application_gateway/variables.tf
+++ b/deployment-scripts/azure/kms/services/application_gateway/variables.tf
@@ -125,6 +125,12 @@ variable "diagnostics_log_analytics_workspace_resource_group_name" {
   default     = ""
 }
 
+variable "public_ip_id" {
+  type        = string
+  description = "Optional resource ID of an existing public IP to use. If empty, a new public IP is created."
+  default     = ""
+}
+
 variable "tags" {
   type        = map(string)
   description = "Tags applied to the Application Gateway."

--- a/deployment-scripts/azure/kms/services/ledger_networking/main.tf
+++ b/deployment-scripts/azure/kms/services/ledger_networking/main.tf
@@ -1,0 +1,64 @@
+# Copyright (c) iSPIRT.
+# Licensed under the Apache License, Version 2.0.
+
+# Private DNS Zone for Confidential Ledger
+# Overrides public DNS so the ledger's FQDN resolves to the private endpoint IP within the VNet.
+resource "azurerm_private_dns_zone" "ledger" {
+  name                = "confidential-ledger.azure.com"
+  resource_group_name = var.resource_group_name
+  tags                = var.tags
+}
+
+# Link Private DNS Zone to Virtual Network
+resource "azurerm_private_dns_zone_virtual_network_link" "ledger" {
+  name                  = "${var.name}-vnet-link"
+  resource_group_name   = var.resource_group_name
+  private_dns_zone_name = azurerm_private_dns_zone.ledger.name
+  virtual_network_id    = var.virtual_network_id
+  registration_enabled  = false
+  tags                  = var.tags
+}
+
+# Private Endpoint connecting to the Ledger's Private Link Service
+resource "azurerm_private_endpoint" "ledger" {
+  name                = "${var.name}-pe"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  subnet_id           = var.private_endpoint_subnet_id
+  tags                = var.tags
+
+  private_service_connection {
+    name                              = "${var.name}-psc"
+    private_connection_resource_alias = var.private_link_service_alias
+    is_manual_connection              = true
+    request_message                   = "Private endpoint for Confidential Ledger"
+  }
+}
+
+# Data source to get the network interface for the private endpoint
+data "azurerm_network_interface" "ledger_pe" {
+  name                = split("/", azurerm_private_endpoint.ledger.network_interface[0].id)[8]
+  resource_group_name = split("/", azurerm_private_endpoint.ledger.network_interface[0].id)[4]
+
+  depends_on = [
+    azurerm_private_endpoint.ledger,
+  ]
+}
+
+# Private DNS A Record for Confidential Ledger
+# Maps the ledger name to the private endpoint IP so that
+# {name}.confidential-ledger.azure.com resolves to the PE IP within the VNet.
+resource "azurerm_private_dns_a_record" "ledger" {
+  name                = var.name
+  zone_name           = azurerm_private_dns_zone.ledger.name
+  resource_group_name = var.resource_group_name
+  ttl                 = 300
+  records             = [data.azurerm_network_interface.ledger_pe.ip_configuration[0].private_ip_address]
+  tags                = var.tags
+
+  depends_on = [
+    azurerm_private_endpoint.ledger,
+    azurerm_private_dns_zone.ledger,
+    data.azurerm_network_interface.ledger_pe,
+  ]
+}

--- a/deployment-scripts/azure/kms/services/ledger_networking/outputs.tf
+++ b/deployment-scripts/azure/kms/services/ledger_networking/outputs.tf
@@ -1,0 +1,22 @@
+# Copyright (c) iSPIRT.
+# Licensed under the Apache License, Version 2.0.
+
+output "private_endpoint_id" {
+  description = "Resource ID of the private endpoint for the Confidential Ledger."
+  value       = azurerm_private_endpoint.ledger.id
+}
+
+output "private_dns_zone_id" {
+  description = "Resource ID of the private DNS zone for the Confidential Ledger."
+  value       = azurerm_private_dns_zone.ledger.id
+}
+
+output "private_dns_zone_name" {
+  description = "Name of the private DNS zone for the Confidential Ledger."
+  value       = azurerm_private_dns_zone.ledger.name
+}
+
+output "ledger_private_fqdn" {
+  description = "Private FQDN for the Confidential Ledger (resolves to the private endpoint IP within the VNet)."
+  value       = "${var.name}.${azurerm_private_dns_zone.ledger.name}"
+}

--- a/deployment-scripts/azure/kms/services/ledger_networking/variables.tf
+++ b/deployment-scripts/azure/kms/services/ledger_networking/variables.tf
@@ -1,0 +1,38 @@
+# Copyright (c) iSPIRT.
+# Licensed under the Apache License, Version 2.0.
+
+variable "name" {
+  type        = string
+  description = "Name of the Confidential Ledger (used for naming private endpoint and DNS records)."
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Resource group that hosts the ledger networking resources."
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region for the private endpoint."
+}
+
+variable "private_link_service_alias" {
+  type        = string
+  description = "Alias of the Private Link Service for the Confidential Ledger (e.g., depa-inferencing-kms-prod-cin-pls.{guid}.centralindia.azure.privatelinkservice)."
+}
+
+variable "private_endpoint_subnet_id" {
+  type        = string
+  description = "Subnet ID for the private endpoint."
+}
+
+variable "virtual_network_id" {
+  type        = string
+  description = "Virtual Network ID for linking the private DNS zone."
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags applied to the networking resources."
+  default     = {}
+}

--- a/deployment-scripts/azure/kms/services/virtual_network/main.tf
+++ b/deployment-scripts/azure/kms/services/virtual_network/main.tf
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0.
 
 resource "azurerm_network_ddos_protection_plan" "this" {
+  count               = var.enable_ddos_protection ? 1 : 0
   name                = "${var.name}-ddos-plan"
   resource_group_name = var.resource_group_name
   location            = var.location
@@ -15,9 +16,12 @@ resource "azurerm_virtual_network" "this" {
   address_space       = var.address_space
   tags                = var.tags
 
-  ddos_protection_plan {
-    id     = azurerm_network_ddos_protection_plan.this.id
-    enable = true
+  dynamic "ddos_protection_plan" {
+    for_each = var.enable_ddos_protection ? [1] : []
+    content {
+      id     = azurerm_network_ddos_protection_plan.this[0].id
+      enable = true
+    }
   }
 }
 

--- a/deployment-scripts/azure/kms/services/virtual_network/variables.tf
+++ b/deployment-scripts/azure/kms/services/virtual_network/variables.tf
@@ -40,3 +40,9 @@ variable "tags" {
   default     = {}
 }
 
+variable "enable_ddos_protection" {
+  type        = bool
+  description = "Whether to create a DDoS Protection Plan and attach it to the Virtual Network."
+  default     = false
+}
+


### PR DESCRIPTION
The KMS deployment previously created all resources (Resource Group, Managed Identity, VNet, Key Vault, Confidential Ledger, Application Gateway) in a single Terraform state. The Application Gateway backend pointed to the ledger's public FQDN. To improve network isolation, the gateway now connects to the ledger via a Private Link Service (created out-of-band), requiring the deployment to be split into phases.

New Deployment Order

Phase 1: terraform/                        → RG, MI, VNet, KV, Ledger
Phase 2: terraform-key-vault-networking/   → KV private endpoints, disable public access
Manual:  Create ledger Private Link Service out-of-band
Phase 3: terraform-application-gateway/    → Ledger PE + private DNS, Application Gateway

Changes

- modules/kms/ — Removed the Application Gateway and its variables/outputs. Phase 1 now only provisions infrastructure up to and including the Confidential Ledger. Added new outputs (virtual_network_name, gateway_subnet_id, ledger_endpoint, confidential_ledger_name) for Phase 3 consumption.

**New** services/ledger_networking/ — Reusable module (following the key_vault_networking pattern) that creates:

- A private endpoint connecting to the ledger's PLS via alias (manual connection)
- A private DNS zone (confidential-ledger.azure.com) that overrides public DNS
- A VNet link and A record so the ledger's original FQDN resolves to the PE's private IP within the VNet

**New** environment/demo/terraform-application-gateway/ — Phase 3 deployment that:

- Discovers Phase 1 resources via data sources
- Fetches the ledger TLS certificate from Azure's identity service
- Calls ledger_networking to set up private connectivity
- Calls application_gateway with the ledger's private FQDN as backend
- Supports using an existing public IP via optional public_ip_id

services/application_gateway/ — Added optional public_ip_id variable. When provided, skips PIP creation and uses the existing one. Backward-compatible (defaults to creating a new PIP).

environment/demo/terraform-key-vault-networking/ — Removed the data.azurerm_application_gateway data source and its outputs, since the gateway may not exist when this phase runs.

environment/demo/terraform/ — Removed gateway-specific config (ssl_certificate_name, diagnostics, allowed_hostname). Replaced hardcoded subscription/tenant IDs with placeholders.