### PR TITLE
Block admin public endpoints

### DIFF
--- a/deployment-scripts/azure/kms/environment/demo/terraform-application-gateway/locals.tf
+++ b/deployment-scripts/azure/kms/environment/demo/terraform-application-gateway/locals.tf
@@ -60,4 +60,7 @@ locals {
   gateway_monitor_unhealthy_alert_severity    = 2
   gateway_monitor_alert_frequency             = "PT1M"
   gateway_monitor_alert_window_size           = "PT5M"
+
+  # Custom allowlist blocks only take effect when mode is Prevention; Detection logs only.
+  waf_firewall_mode = "Prevention"
 }

--- a/deployment-scripts/azure/kms/environment/demo/terraform-application-gateway/main.tf
+++ b/deployment-scripts/azure/kms/environment/demo/terraform-application-gateway/main.tf
@@ -89,6 +89,7 @@ module "application_gateway" {
   acme_challenge_backend_fqdn                             = module.letsencrypt_storage.web_endpoint_host
   capacity                                                = local.application_gateway_capacity
   public_ip_id                                            = local.application_gateway_public_ip_id
+  waf_firewall_mode                                       = local.waf_firewall_mode
 
   gateway_monitor_unhealthy_alert_enabled     = local.gateway_monitor_unhealthy_alert_enabled
   gateway_monitor_alert_email_addresses       = local.gateway_monitor_alert_email_addresses

--- a/deployment-scripts/azure/kms/services/application_gateway/main.tf
+++ b/deployment-scripts/azure/kms/services/application_gateway/main.tf
@@ -15,6 +15,11 @@ locals {
   # Trim any trailing slash from URI to avoid double slashes
   key_vault_uri_trimmed               = trimsuffix(var.key_vault_uri, "/")
   ssl_certificate_key_vault_secret_id = "${local.key_vault_uri_trimmed}/secrets/${var.ssl_certificate_name}"
+
+  # Public URI allowlist (Lowercase+UrlDecode via WAF rule). Empty waf_allowed_public_uri_regex → regex below. Extend for e.g. /.well-known if HTTP+ACME shares this policy.
+  # listpubkeys: optional / and ?query. key/unwrapkey: query must include fmt=tink.
+  default_kms_public_uri_allow_regex = "^(/app/listpubkeys/?(?:\\?[^#]*)?$|/app/key\\?(?:[^#]*&)*fmt=tink(?:&[^#]*)?$|/app/unwrapkey\\?(?:[^#]*&)*fmt=tink(?:&[^#]*)?)$"
+  kms_public_uri_allow_regex         = var.waf_allowed_public_uri_regex != "" ? var.waf_allowed_public_uri_regex : local.default_kms_public_uri_allow_regex
 }
 
 resource "azurerm_public_ip" "gateway" {
@@ -58,6 +63,26 @@ resource "azurerm_web_application_firewall_policy" "this" {
     managed_rule_set {
       type    = var.waf_rule_set_type
       version = var.waf_rule_set_version
+
+      # CRS 942340/430/440 false-positive KMS JSON bodies; TF exclusions cannot scope by RequestUri. KMS-only policy — do not reuse blindly.
+      dynamic "rule_group_override" {
+        for_each = var.waf_sqli_rule_overrides_enabled && var.waf_rule_set_type == "OWASP" ? [1] : []
+        content {
+          rule_group_name = "REQUEST-942-APPLICATION-ATTACK-SQLI"
+          rule {
+            id      = "942340"
+            enabled = false
+          }
+          rule {
+            id      = "942430"
+            enabled = false
+          }
+          rule {
+            id      = "942440"
+            enabled = false
+          }
+        }
+      }
     }
   }
 
@@ -67,8 +92,7 @@ resource "azurerm_web_application_firewall_policy" "this" {
     rule_type = "MatchRule"
     action    = "Block"
 
-    # Block requests where Host header does not match the allowed hostname
-    # Uses "Equal" operator with negation: block if Host does NOT equal the allowed hostname
+    # Block unless Host equals allowed_hostname exactly.
     match_conditions {
       match_variables {
         variable_name = "RequestHeaders"
@@ -80,21 +104,24 @@ resource "azurerm_web_application_firewall_policy" "this" {
     }
   }
 
-  custom_rules {
-    name      = "BlockAdminEndpoints"
-    priority  = 2
-    rule_type = "MatchRule"
-    action    = "Block"
+  dynamic "custom_rules" {
+    for_each = var.waf_public_allowlist_enabled ? [1] : []
+    content {
+      name      = "BlockOutsideKmsPublicApi"
+      priority  = 2
+      rule_type = "MatchRule"
+      action    = "Block"
 
-    # Block admin / control-plane KMS paths from the public AGW. Workflows reach
-    # these via the ledger's private endpoint inside the VNet, bypassing the AGW.
-    match_conditions {
-      match_variables {
-        variable_name = "RequestUri"
+      # Block if RequestUri does not match allowlist (Regex + negation_condition).
+      match_conditions {
+        match_variables {
+          variable_name = "RequestUri"
+        }
+        operator           = "Regex"
+        match_values       = [local.kms_public_uri_allow_regex]
+        negation_condition = true
+        transforms         = ["Lowercase", "UrlDecode"]
       }
-      operator     = "Regex"
-      match_values = ["^/app/(heartbeat|auth|refresh|keyReleasePolicy|settingsPolicy|jwtValidationPolicy|proposals)(/|\\?|$)"]
-      transforms   = ["Lowercase", "UrlDecode"]
     }
   }
 

--- a/deployment-scripts/azure/kms/services/application_gateway/main.tf
+++ b/deployment-scripts/azure/kms/services/application_gateway/main.tf
@@ -80,6 +80,24 @@ resource "azurerm_web_application_firewall_policy" "this" {
     }
   }
 
+  custom_rules {
+    name      = "BlockAdminEndpoints"
+    priority  = 2
+    rule_type = "MatchRule"
+    action    = "Block"
+
+    # Block admin / control-plane KMS paths from the public AGW. Workflows reach
+    # these via the ledger's private endpoint inside the VNet, bypassing the AGW.
+    match_conditions {
+      match_variables {
+        variable_name = "RequestUri"
+      }
+      operator     = "Regex"
+      match_values = ["^/app/(heartbeat|auth|refresh|keyReleasePolicy|settingsPolicy|jwtValidationPolicy|proposals)(/|\\?|$)"]
+      transforms   = ["Lowercase", "UrlDecode"]
+    }
+  }
+
 }
 
 resource "azurerm_application_gateway" "this" {

--- a/deployment-scripts/azure/kms/services/application_gateway/main.tf
+++ b/deployment-scripts/azure/kms/services/application_gateway/main.tf
@@ -18,6 +18,7 @@ locals {
 
   # Public URI allowlist (Lowercase+UrlDecode via WAF rule). Empty waf_allowed_public_uri_regex → regex below.
   # Optional trailing slash + optional query per path. Override for e.g. /.well-known if HTTP+ACME shares this policy.
+  # Public KMS paths (sans pubkey): pubkey uses a separate BeginsWith rule — Azure Regex alternation skipped it wrongly.
   default_kms_public_uri_allow_regex = "^(/app/listpubkeys/?(?:\\?[^#]*)?$|/app/key/?(?:\\?[^#]*)?$|/app/unwrapkey/?(?:\\?[^#]*)?)$"
   kms_public_uri_allow_regex         = var.waf_allowed_public_uri_regex != "" ? var.waf_allowed_public_uri_regex : local.default_kms_public_uri_allow_regex
 }
@@ -104,22 +105,102 @@ resource "azurerm_web_application_firewall_policy" "this" {
     }
   }
 
+  # Order: pubkey Allow → composite Allow → Block remaining /app/* → block CCF routes (regex must wholly match URIs).
   dynamic "custom_rules" {
     for_each = var.waf_public_allowlist_enabled ? [1] : []
     content {
-      name      = "BlockOutsideKmsPublicApi"
+      name      = "AllowKmsPubkeyPath"
       priority  = 2
       rule_type = "MatchRule"
-      action    = "Block"
+      action    = "Allow"
 
-      # Block if RequestUri does not match allowlist (Regex + negation_condition).
+      match_conditions {
+        match_variables {
+          variable_name = "RequestUri"
+        }
+        operator           = "BeginsWith"
+        match_values       = ["/app/pubkey"]
+        negation_condition = false
+        transforms         = ["Lowercase", "UrlDecode"]
+      }
+    }
+  }
+
+  dynamic "custom_rules" {
+    for_each = var.waf_public_allowlist_enabled ? [1] : []
+    content {
+      name      = "AllowKmsPublicApiPaths"
+      priority  = 3
+      rule_type = "MatchRule"
+      action    = "Allow"
+
       match_conditions {
         match_variables {
           variable_name = "RequestUri"
         }
         operator           = "Regex"
         match_values       = [local.kms_public_uri_allow_regex]
-        negation_condition = true
+        negation_condition = false
+        transforms         = ["Lowercase", "UrlDecode"]
+      }
+    }
+  }
+
+  dynamic "custom_rules" {
+    for_each = var.waf_public_allowlist_enabled ? [1] : []
+    content {
+      name      = "BlockUnlistedAppPaths"
+      priority  = 4
+      rule_type = "MatchRule"
+      action    = "Block"
+
+      match_conditions {
+        match_variables {
+          variable_name = "RequestUri"
+        }
+        operator           = "Regex"
+        match_values       = ["^/app/"]
+        negation_condition = false
+        transforms         = ["Lowercase", "UrlDecode"]
+      }
+    }
+  }
+
+  dynamic "custom_rules" {
+    for_each = var.waf_public_allowlist_enabled ? [1] : []
+    content {
+      name      = "BlockNodeAndGovPrefixes"
+      priority  = 5
+      rule_type = "MatchRule"
+      action    = "Block"
+
+      match_conditions {
+        match_variables {
+          variable_name = "RequestUri"
+        }
+        operator           = "Regex"
+        match_values       = ["^/(node|gov)(/.*)?$"]
+        negation_condition = false
+        transforms         = ["Lowercase", "UrlDecode"]
+      }
+    }
+  }
+
+  dynamic "custom_rules" {
+    for_each = var.waf_public_allowlist_enabled ? [1] : []
+    content {
+      name      = "BlockReceiptPrefixes"
+      priority  = 6
+      rule_type = "MatchRule"
+      action    = "Block"
+
+      match_conditions {
+        match_variables {
+          variable_name = "RequestUri"
+        }
+        operator           = "BeginsWith"
+        match_values       = ["/receipt"]
+        negation_condition = false
         transforms         = ["Lowercase", "UrlDecode"]
       }
     }
@@ -146,7 +227,8 @@ resource "azurerm_application_gateway" "this" {
     capacity = var.capacity
   }
 
-  firewall_policy_id = azurerm_web_application_firewall_policy.this.id
+  firewall_policy_id                = azurerm_web_application_firewall_policy.this.id
+  force_firewall_policy_association = true
 
   gateway_ip_configuration {
     name      = "depa-inferencing-gateway-ip-config"

--- a/deployment-scripts/azure/kms/services/application_gateway/main.tf
+++ b/deployment-scripts/azure/kms/services/application_gateway/main.tf
@@ -16,9 +16,9 @@ locals {
   key_vault_uri_trimmed               = trimsuffix(var.key_vault_uri, "/")
   ssl_certificate_key_vault_secret_id = "${local.key_vault_uri_trimmed}/secrets/${var.ssl_certificate_name}"
 
-  # Public URI allowlist (Lowercase+UrlDecode via WAF rule). Empty waf_allowed_public_uri_regex → regex below. Extend for e.g. /.well-known if HTTP+ACME shares this policy.
-  # listpubkeys: optional / and ?query. key/unwrapkey: query must include fmt=tink.
-  default_kms_public_uri_allow_regex = "^(/app/listpubkeys/?(?:\\?[^#]*)?$|/app/key\\?(?:[^#]*&)*fmt=tink(?:&[^#]*)?$|/app/unwrapkey\\?(?:[^#]*&)*fmt=tink(?:&[^#]*)?)$"
+  # Public URI allowlist (Lowercase+UrlDecode via WAF rule). Empty waf_allowed_public_uri_regex → regex below.
+  # Optional trailing slash + optional query per path. Override for e.g. /.well-known if HTTP+ACME shares this policy.
+  default_kms_public_uri_allow_regex = "^(/app/listpubkeys/?(?:\\?[^#]*)?$|/app/key/?(?:\\?[^#]*)?$|/app/unwrapkey/?(?:\\?[^#]*)?)$"
   kms_public_uri_allow_regex         = var.waf_allowed_public_uri_regex != "" ? var.waf_allowed_public_uri_regex : local.default_kms_public_uri_allow_regex
 }
 

--- a/deployment-scripts/azure/kms/services/application_gateway/variables.tf
+++ b/deployment-scripts/azure/kms/services/application_gateway/variables.tf
@@ -68,6 +68,24 @@ variable "waf_rule_set_version" {
   default     = "3.2"
 }
 
+variable "waf_sqli_rule_overrides_enabled" {
+  type        = bool
+  description = "OWASP CRS: disable rules 942340/942430/942440 on this policy only (KMS JSON false positives). Required before Prevention if key/unwrap POSTs must succeed."
+  default     = true
+}
+
+variable "waf_public_allowlist_enabled" {
+  type        = bool
+  description = "If true: block RequestUri outside default allow regex (or waf_allowed_public_uri_regex when set)."
+  default     = true
+}
+
+variable "waf_allowed_public_uri_regex" {
+  type        = string
+  description = "Non-empty → full permitted RequestUri regex (after WAF transforms). Empty → built-in: listpubkeys (+ optional /, ?query); key & unwrapkey require fmt=tink in query."
+  default     = ""
+}
+
 variable "capacity" {
   type        = number
   description = "Capacity (instance count) for the Application Gateway."

--- a/deployment-scripts/azure/kms/services/application_gateway/variables.tf
+++ b/deployment-scripts/azure/kms/services/application_gateway/variables.tf
@@ -82,7 +82,7 @@ variable "waf_public_allowlist_enabled" {
 
 variable "waf_allowed_public_uri_regex" {
   type        = string
-  description = "Non-empty → full permitted RequestUri regex (after WAF transforms). Empty → built-in: listpubkeys (+ optional /, ?query); key & unwrapkey require fmt=tink in query."
+  description = "Non-empty → full permitted RequestUri regex (after WAF transforms). Empty → built-in: listpubkeys, key, unwrapkey (+ optional slash, optional query)."
   default     = ""
 }
 

--- a/deployment-scripts/azure/kms/services/application_gateway/variables.tf
+++ b/deployment-scripts/azure/kms/services/application_gateway/variables.tf
@@ -82,7 +82,7 @@ variable "waf_public_allowlist_enabled" {
 
 variable "waf_allowed_public_uri_regex" {
   type        = string
-  description = "Non-empty → full permitted RequestUri regex (after WAF transforms). Empty → built-in: listpubkeys, key, unwrapkey (+ optional slash, optional query)."
+  description = "Non-empty → full permitted RequestUri regex (after WAF transforms). Empty → built-in: listpubkeys, pubkey, key, unwrapkey (+ optional slash, optional query)."
   default     = ""
 }
 


### PR DESCRIPTION
Goal: On the public KMS hostname, only client key flows stay open; admin and platform routes must go through private access (VNet / ledger private FQDN).

What changes:
- Application Gateway WAF is set to Prevention (via locals.tf) so rules are enforced.
- force_firewall_policy_association = true so the WAF policy is reliably applied.
- Custom rules:
  - Allow GET /app/pubkey (BeginsWith), GET allowlist regex for listpubkeys, POST paths for key / unwrapKey (fmt preserved).
  - Block any other /app/... (admin APIs: heartbeat, refresh, proposals, policies, etc.).
  - Block /node/..., /gov/..., /receipt... so CCF ledger surfaces aren’t exposed on the public listener.
- OWASP CRS: selectively disable 942340 / 942430 / 942440 on this policy so legitimate KMS JSON/key/unwrapKey POSTs aren’t tripped before enforcement.