### PR TITLE
KMS cert refresh automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ __pycache__
 # .tfstate files
 *.tfstate
 *.tfstate.*
+*.tfvars
+*.tfplan
 .terraform
 .terraform.lock.hcl
 # Python virtual environments

--- a/deployment-scripts/azure/kms/MANUAL_FRONTEND_CERT_RENEWAL.md
+++ b/deployment-scripts/azure/kms/MANUAL_FRONTEND_CERT_RENEWAL.md
@@ -1,0 +1,341 @@
+# Manual KMS frontend TLS certificate renewal (DNS-01)
+
+Use this runbook when the Application Gateway HTTPS certificate for Azure KMS is expired or near expiry, and you need to renew it **manually** with Let's Encrypt.
+
+**Preferred path (when CI works):** trigger the GitHub Action [Refresh KMS frontend certificate](../../../.github/workflows/refresh_kms_frontend_certificate.yml) (`environment=prod` or `uat`, `acme-server=production`). That uses HTTP-01 automatically. Use **this** runbook only when that workflow is unavailable or you must renew by hand.
+
+Let's Encrypt certs are valid ~90 days. Renew before expiry (e.g. when < 30 days remain).
+
+---
+
+## What you are updating
+
+Fill these from your target environment (portal, `az`, or the refresh workflow env vars). Do not hardcode them into shared docs.
+
+| Variable | Meaning | How to find it |
+|---|---|---|
+| `SUBSCRIPTION_ID` | Azure subscription | `az account show --query id -o tsv` (after selecting the right account) |
+| `DOMAIN` | Public KMS frontend hostname | DNS / App Gateway HTTPS listener host name |
+| `RG` | Resource group of the App Gateway + Key Vault | Portal or `az group list` |
+| `AGW` | Application Gateway name | Portal or `az network application-gateway list -g "$RG" -o table` |
+| `VAULT` | Key Vault that holds the frontend TLS cert | Portal or `az keyvault list -g "$RG" -o table` |
+| `CERT_NAME` | Certificate name inside Key Vault (also the AGW SSL cert name) | `az network application-gateway ssl-cert list -g "$RG" --gateway-name "$AGW" -o table` |
+| `EMAIL` | Contact for Let's Encrypt notices | Your team ops email |
+
+The App Gateway does **not** store the PFX itself. It reads the cert from Key Vault. You must:
+
+1. Issue a new Let's Encrypt cert (DNS-01).
+2. Import it into Key Vault under the **existing** certificate name (creates a new version).
+3. Force the App Gateway to re-bind that new version.
+4. Lock Key Vault public access again and verify HTTPS.
+
+---
+
+## Prerequisites
+
+- Azure CLI (`az`) installed and logged in: `az login`
+- Correct subscription selected
+- `openssl` and `certbot` installed (`sudo apt-get install -y certbot` on Debian/Ubuntu)
+- Permission to:
+  - import certificates into the Key Vault (`Key Vault Certificates Officer` or equivalent)
+  - update the Application Gateway
+  - temporarily change Key Vault networking (`publicNetworkAccess`)
+- A **sysadmin** who can add/remove a DNS **TXT** record for the KMS hostname's zone (you will send them one value; you cannot complete ACME without it)
+
+Working directory suggestion:
+
+```bash
+mkdir -p ~/kms-cert-renewal && cd ~/kms-cert-renewal
+```
+
+Set environment variables once:
+
+```bash
+export SUBSCRIPTION_ID="<subscription-id>"
+export DOMAIN="<kms-frontend-hostname>"
+export RG="<resource-group>"
+export AGW="<application-gateway-name>"
+export VAULT="<key-vault-name>"
+export CERT_NAME="<frontend-cert-name>"
+export EMAIL="<team-email>"   # used for Let's Encrypt account notices
+
+az account set --subscription "$SUBSCRIPTION_ID"
+az account show -o table
+```
+
+---
+
+## Step 0 — Confirm the live cert is the problem
+
+```bash
+echo | openssl s_client -connect "${DOMAIN}:443" -servername "$DOMAIN" 2>/dev/null \
+  | openssl x509 -noout -subject -issuer -dates
+```
+
+If `notAfter` is in the past or within ~30 days, continue.
+
+Optional backend sanity check (ignores TLS expiry):
+
+```bash
+curl -skS "https://${DOMAIN}/app/listpubkeys"
+```
+
+You should get HTTP 200 and a JSON `keys` payload even if TLS is expired.
+
+---
+
+## Step 1 — Request a new Let's Encrypt certificate (DNS-01)
+
+```bash
+mkdir -p ./le/{config,work,logs}
+
+certbot certonly \
+  --manual \
+  --preferred-challenges dns \
+  --agree-tos \
+  --email "$EMAIL" \
+  -d "$DOMAIN" \
+  --config-dir ./le/config \
+  --work-dir ./le/work \
+  --logs-dir ./le/logs
+```
+
+Certbot will pause and print something like:
+
+```text
+Please deploy a DNS TXT record under the name:
+_acme-challenge.<kms-frontend-hostname>
+with the following value:
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+### Send this to the sysadmin
+
+Use a message like:
+
+> Please add the following DNS TXT record, wait for propagation, and reply when live:
+>
+> - **Name / host:** `_acme-challenge.<kms-frontend-hostname>`  
+>   (or `_acme-challenge` under the relevant DNS zone, depending on how DNS is managed)
+> - **Type:** TXT  
+> - **Value:** `<paste the exact value certbot printed>`  
+> - **TTL:** 300 (or default)
+
+Do **not** press Enter in certbot until the record is visible publicly.
+
+### Confirm the TXT record is live
+
+```bash
+dig +short TXT _acme-challenge."$DOMAIN"
+# or:
+nslookup -type=TXT _acme-challenge."$DOMAIN"
+```
+
+When the expected value appears, return to the certbot prompt and press Enter.
+
+On success, files land under:
+
+```text
+./le/config/live/<DOMAIN>/fullchain.pem
+./le/config/live/<DOMAIN>/privkey.pem
+```
+
+Inspect:
+
+```bash
+openssl x509 -in "./le/config/live/${DOMAIN}/fullchain.pem" -noout -subject -issuer -dates
+```
+
+Expect `subject` CN/SAN = your `$DOMAIN` and a `notAfter` ~90 days out.
+
+Ask the sysadmin to **remove** the `_acme-challenge` TXT record after issuance succeeds (optional but recommended).
+
+---
+
+## Step 2 — Bundle cert + key as a PFX
+
+Azure Key Vault import expects PKCS#12. Use an **empty** PFX password (matches the automated workflow):
+
+```bash
+openssl pkcs12 -export \
+  -inkey "./le/config/live/${DOMAIN}/privkey.pem" \
+  -in    "./le/config/live/${DOMAIN}/fullchain.pem" \
+  -out   ./frontend.pfx \
+  -passout pass:
+
+openssl pkcs12 -in ./frontend.pfx -nokeys -passin pass: \
+  | openssl x509 -noout -subject -issuer -dates
+```
+
+---
+
+## Step 3 — Temporarily allow your IP to reach Key Vault
+
+KMS Key Vaults normally have **`publicNetworkAccess: Disabled`**. From a laptop you must open access briefly, import, then lock it again.
+
+```bash
+MY_IP="$(curl -s https://ifconfig.me)"
+echo "My public IP: $MY_IP"
+
+az keyvault update --name "$VAULT" --public-network-access Enabled
+az keyvault network-rule add --name "$VAULT" --ip-address "$MY_IP"
+```
+
+If `network-rule add` says the IP already exists, that is fine.
+
+> If you are already on a jump host / runner that reaches the vault over private endpoint, skip this step and go straight to import.
+
+---
+
+## Step 4 — Import the new certificate version into Key Vault
+
+Import under the **same** certificate name (do not create a differently named cert):
+
+```bash
+az keyvault certificate import \
+  --vault-name "$VAULT" \
+  --name "$CERT_NAME" \
+  --file ./frontend.pfx \
+  --password ""
+```
+
+Confirm the new version:
+
+```bash
+az keyvault certificate show \
+  --vault-name "$VAULT" \
+  --name "$CERT_NAME" \
+  --query "{id:id, sid:sid, thumbprint:x509ThumbprintHex, notBefore:attributes.notBefore, notAfter:attributes.expires}" \
+  -o json
+```
+
+Copy `sid` — that is the **versioned** secret ID (ends with a GUID). You need it for the App Gateway force-refresh.
+
+```bash
+export NEW_SID="$(az keyvault certificate show \
+  --vault-name "$VAULT" \
+  --name "$CERT_NAME" \
+  --query sid -o tsv)"
+echo "$NEW_SID"
+```
+
+---
+
+## Step 5 — Force Application Gateway to use the new cert
+
+A plain `az network application-gateway update` is **not reliable**. Re-bind the SSL certificate to the new Key Vault secret version, then restore the versionless ID so future imports can auto-pick up.
+
+```bash
+export VERSIONLESS="https://${VAULT}.vault.azure.net/secrets/${CERT_NAME}"
+
+# 5a) Point AGW at the new version explicitly
+az network application-gateway ssl-cert update \
+  --resource-group "$RG" \
+  --gateway-name "$AGW" \
+  --name "$CERT_NAME" \
+  --key-vault-secret-id "$NEW_SID"
+
+# Wait for the gateway to finish updating, then check live TLS
+sleep 20
+echo | openssl s_client -connect "${DOMAIN}:443" -servername "$DOMAIN" 2>/dev/null \
+  | openssl x509 -noout -subject -issuer -dates
+```
+
+**Stop here if dates are still the old expiry.** Do not continue until live TLS shows the new `notAfter`.
+
+```bash
+# 5b) Restore versionless secret ID (keeps future renewals simpler)
+az network application-gateway ssl-cert update \
+  --resource-group "$RG" \
+  --gateway-name "$AGW" \
+  --name "$CERT_NAME" \
+  --key-vault-secret-id "$VERSIONLESS"
+```
+
+---
+
+## Step 6 — Lock Key Vault again
+
+```bash
+az keyvault update --name "$VAULT" --public-network-access Disabled
+
+# Remove the temporary IP allow rule
+az keyvault network-rule remove --name "$VAULT" --ip-address "$MY_IP"
+```
+
+Confirm:
+
+```bash
+az keyvault show --name "$VAULT" \
+  --query "{publicNetworkAccess:properties.publicNetworkAccess, ipRules:properties.networkAcls.ipRules}" \
+  -o json
+```
+
+Expect `publicNetworkAccess` = `Disabled`.
+
+---
+
+## Step 7 — End-to-end verification
+
+```bash
+# TLS must verify without -k and show the new dates
+echo | openssl s_client -connect "${DOMAIN}:443" -servername "$DOMAIN" 2>/dev/null \
+  | openssl x509 -noout -subject -issuer -dates
+
+# Application endpoint must succeed with normal TLS verification
+curl -sS -w "\nHTTP_CODE:%{http_code}\n" "https://${DOMAIN}/app/listpubkeys"
+```
+
+**Success criteria:**
+
+- Live cert `notAfter` matches the newly issued cert (~90 days out)
+- `curl` returns HTTP `200` and JSON containing `"keys"`
+- No `SSL certificate problem: certificate has expired`
+
+---
+
+## Step 8 — Clean up local secrets
+
+```bash
+shred -u ./frontend.pfx 2>/dev/null || rm -f ./frontend.pfx
+rm -rf ./le
+```
+
+Do not commit PFX/PEM files to git. Do not paste private keys into tickets/chat.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Certbot stuck / DNS validation failed | TXT not propagated or wrong name/value | Re-check `dig TXT _acme-challenge.$DOMAIN`; fix with sysadmin; retry certbot |
+| `ForbiddenByConnection` on Key Vault | Public access still disabled / IP not allowed | Repeat Step 3 |
+| KV import OK but browser/curl still shows old/expired cert | AGW did not refresh | Repeat Step 5a with the current `sid`; wait 20–60s and re-check |
+| `ssl-cert update` fails to fetch secret | AGW identity cannot read KV, or vault locked before AGW fetched | Ensure Step 5 runs **before** Step 6; confirm AGW MI still has Key Vault Secrets User on the vault |
+| `/app/listpubkeys` TLS OK but non-200 | Backend / ledger issue, not cert | Investigate KMS backend separately; cert renewal is done |
+
+---
+
+## One-page command checklist
+
+```bash
+# vars — fill from your environment
+export SUBSCRIPTION_ID="<subscription-id>"
+export DOMAIN="<kms-frontend-hostname>"
+export RG="<resource-group>"
+export AGW="<application-gateway-name>"
+export VAULT="<key-vault-name>"
+export CERT_NAME="<frontend-cert-name>"
+export EMAIL="<team-email>"
+az account set --subscription "$SUBSCRIPTION_ID"
+
+# 1) certbot DNS-01 → send TXT to sysadmin → continue when dig shows it
+# 2) openssl pkcs12 → frontend.pfx (empty password)
+# 3) open KV to MY_IP
+# 4) az keyvault certificate import ... ; export NEW_SID=...
+# 5) ssl-cert update → NEW_SID ; verify dates ; ssl-cert update → versionless
+# 6) disable KV public access ; remove MY_IP rule
+# 7) openssl s_client dates + curl https://$DOMAIN/app/listpubkeys
+# 8) delete local pfx/le dirs
+```

--- a/deployment-scripts/azure/kms/README.md
+++ b/deployment-scripts/azure/kms/README.md
@@ -170,6 +170,17 @@ Required GitHub secret (in addition to the existing `AZURE_AKS_*` OIDC secrets):
 
 For a **manual** renewal (Let's Encrypt DNS-01 with sysadmin TXT update, Key Vault import, and App Gateway force-refresh), follow [MANUAL_FRONTEND_CERT_RENEWAL.md](MANUAL_FRONTEND_CERT_RENEWAL.md).
 
+## Refreshing the ledger TLS trusted-root certificate
+
+The Application Gateway pins the Confidential Ledger's TLS identity certificate as a **trusted root** for backend HTTPS. When the ledger (CCF) restarts, that identity certificate regenerates. If the gateway is not updated, backend TLS validation fails and clients see **502** errors.
+
+There is no Azure control-plane event for ledger restarts, so renewal is handled by an optional **ledger cert reconciler** add-on:
+
+- Module: [`services/ledger_cert_reconciler/`](services/ledger_cert_reconciler/) (see its README for purpose, safety properties, and manual tests)
+- Deploy root: [`environment/demo/terraform-ledger-cert-reconciler/`](environment/demo/terraform-ledger-cert-reconciler/) — **own Terraform state**, additive only (does not rewrite the Phase 3 gateway)
+
+It polls the public ledger identity endpoint on a timer (default every minute) and updates the gateway's trusted root only when the thumbprint changes. An `UnhealthyHostCount` metric alert can also trigger an immediate reconcile via an HTTP function.
+
 ## State Migration and Recovery
 
 The repository includes [environment/demo/import-state.sh](environment/demo/import-state.sh) for rebuilding Terraform state from an existing Azure deployment. The script:

--- a/deployment-scripts/azure/kms/README.md
+++ b/deployment-scripts/azure/kms/README.md
@@ -168,6 +168,8 @@ Required GitHub secret (in addition to the existing `AZURE_AKS_*` OIDC secrets):
 
 - `LETSENCRYPT_EMAIL` — email used to register the ACME account.
 
+For a **manual** renewal (Let's Encrypt DNS-01 with sysadmin TXT update, Key Vault import, and App Gateway force-refresh), follow [MANUAL_FRONTEND_CERT_RENEWAL.md](MANUAL_FRONTEND_CERT_RENEWAL.md).
+
 ## State Migration and Recovery
 
 The repository includes [environment/demo/import-state.sh](environment/demo/import-state.sh) for rebuilding Terraform state from an existing Azure deployment. The script:

--- a/deployment-scripts/azure/kms/environment/demo/terraform-ledger-cert-reconciler/locals.tf
+++ b/deployment-scripts/azure/kms/environment/demo/terraform-ledger-cert-reconciler/locals.tf
@@ -1,0 +1,29 @@
+# Copyright (c) iSPIRT.
+# Licensed under the Apache License, Version 2.0.
+
+locals {
+  environment  = "uat" # uat or prod
+  region_short = "cin"
+
+  resource_group_name      = "depa-inferencing-kms-${local.environment}-${local.region_short}-rg"
+  application_gateway_name = "depa-inferencing-kms-${local.environment}-${local.region_short}-agw"
+  ledger_name              = "depa-inferencing-kms-${local.environment}-${local.region_short}"
+
+  # Must match the trusted root certificate entry name on the gateway backend
+  # HTTP settings (see services/application_gateway).
+  trusted_root_certificate_name = "ledger-root-cert"
+
+  # Storage account: globally unique, <=24 lowercase alphanumeric.
+  storage_account_name = "depainfkmsrec${local.environment}${local.region_short}"
+  function_app_name    = "depa-inferencing-kms-${local.environment}-${local.region_short}-agw-certsync"
+
+  # NCRONTAB: every minute.
+  reconcile_schedule = "0 */1 * * * *"
+
+  tags = {
+    Environment = local.environment
+    ManagedBy   = "Terraform"
+    Owner       = "ispirt"
+    Workload    = "depa-inferencing-kms"
+  }
+}

--- a/deployment-scripts/azure/kms/environment/demo/terraform-ledger-cert-reconciler/main.tf
+++ b/deployment-scripts/azure/kms/environment/demo/terraform-ledger-cert-reconciler/main.tf
@@ -1,0 +1,37 @@
+# Copyright (c) iSPIRT.
+# Licensed under the Apache License, Version 2.0.
+#
+# Standalone deployment of the ledger certificate reconciler.
+#
+# This root has its OWN Terraform state and does not manage any phase-3 resource.
+# It only reads the existing Application Gateway (data source) and creates the
+# additive reconciler resources (Function App + identity + AGW-scoped role +
+# alert). It cannot modify the gateway definition, backend pools, listeners,
+# WAF, or any other KMS resource.
+
+data "azurerm_client_config" "current" {}
+
+# Existing Application Gateway created by phase-3 (terraform-application-gateway).
+data "azurerm_application_gateway" "agw" {
+  name                = local.application_gateway_name
+  resource_group_name = local.resource_group_name
+}
+
+module "ledger_cert_reconciler" {
+  source = "../../../services/ledger_cert_reconciler"
+
+  resource_group_name = local.resource_group_name
+  location            = data.azurerm_application_gateway.agw.location
+  subscription_id     = data.azurerm_client_config.current.subscription_id
+
+  application_gateway_id        = data.azurerm_application_gateway.agw.id
+  application_gateway_name      = local.application_gateway_name
+  ledger_name                   = local.ledger_name
+  trusted_root_certificate_name = local.trusted_root_certificate_name
+
+  storage_account_name = local.storage_account_name
+  function_app_name    = local.function_app_name
+  reconcile_schedule   = local.reconcile_schedule
+
+  tags = local.tags
+}

--- a/deployment-scripts/azure/kms/environment/demo/terraform-ledger-cert-reconciler/outputs.tf
+++ b/deployment-scripts/azure/kms/environment/demo/terraform-ledger-cert-reconciler/outputs.tf
@@ -1,0 +1,22 @@
+# Copyright (c) iSPIRT.
+# Licensed under the Apache License, Version 2.0.
+
+output "function_app_name" {
+  description = "Name of the reconciler Function App."
+  value       = module.ledger_cert_reconciler.function_app_name
+}
+
+output "function_app_default_hostname" {
+  description = "Default hostname of the reconciler Function App."
+  value       = module.ledger_cert_reconciler.function_app_default_hostname
+}
+
+output "function_identity_principal_id" {
+  description = "Managed identity principal ID of the reconciler Function App."
+  value       = module.ledger_cert_reconciler.function_identity_principal_id
+}
+
+output "metric_alert_id" {
+  description = "Metric alert that triggers immediate reconcile when the ledger backend goes unhealthy."
+  value       = module.ledger_cert_reconciler.metric_alert_id
+}

--- a/deployment-scripts/azure/kms/environment/demo/terraform-ledger-cert-reconciler/terraform.tf
+++ b/deployment-scripts/azure/kms/environment/demo/terraform-ledger-cert-reconciler/terraform.tf
@@ -1,0 +1,24 @@
+# Copyright (c) iSPIRT.
+# Licensed under the Apache License, Version 2.0.
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.54"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.4"
+    }
+  }
+}
+
+# Authentication comes from the ambient Azure CLI / environment (az login).
+# This root manages ONLY the ledger cert reconciler add-on and keeps its own
+# state, fully isolated from the phase-3 gateway deployment.
+provider "azurerm" {
+  features {}
+}

--- a/deployment-scripts/azure/kms/services/ledger_cert_reconciler/.gitignore
+++ b/deployment-scripts/azure/kms/services/ledger_cert_reconciler/.gitignore
@@ -1,0 +1,2 @@
+# Build artifact produced by archive_file at plan/apply time.
+build/

--- a/deployment-scripts/azure/kms/services/ledger_cert_reconciler/README.md
+++ b/deployment-scripts/azure/kms/services/ledger_cert_reconciler/README.md
@@ -1,0 +1,52 @@
+# Ledger certificate reconciler
+
+Keeps the Application Gateway's trusted root certificate in sync with the
+Confidential Ledger's TLS identity certificate.
+
+## Why this exists
+
+When Azure Confidential Ledger (CCF) restarts, it regenerates its self-signed
+service identity certificate. The Application Gateway pins that certificate as
+the trusted root for the ledger backend HTTPS settings. After a rotation the
+gateway keeps trusting the previous cert, backend TLS validation fails, and
+clients receive 502s until the gateway is updated.
+
+There is no control-plane event when the ledger restarts, so this function:
+
+1. **Timer** (default every minute) fetches the live identity certificate and
+   updates the gateway only when the thumbprint differs.
+2. **HTTP trigger** does the same on demand, wired from an
+   `UnhealthyHostCount` metric alert for immediate reaction if a rotation is
+   already causing unhealthy backends.
+
+## Safety properties
+
+- Additive only: it never recreates or rewrites the Application Gateway
+  definition (listeners, pools, WAF, frontend cert, etc.).
+- Least privilege: system-assigned MI with a custom role scoped to the single
+  gateway (`read`/`write`/`backendHealth`).
+- Idempotent: stores `ledgerRootThumbprint` as a tag on the gateway and skips
+  writes when already up to date.
+- Standalone Terraform root under
+  `environment/demo/terraform-ledger-cert-reconciler/` with its own state, so
+  applying it cannot drift phase-3 gateway state.
+
+## Deploy (UAT / demo)
+
+```bash
+az account set --subscription <uat-subscription-id>
+cd deployment-scripts/azure/kms/environment/demo/terraform-ledger-cert-reconciler
+terraform init
+terraform plan
+terraform apply
+```
+
+## Manual test
+
+```bash
+# Invoke the HTTP trigger (get function key from portal or az)
+curl -sS "https://<function-app-hostname>/api/ReconcileHttp?code=<function-key>"
+
+# Confirm KMS still healthy
+curl -i https://<kms-frontend-hostname>/app/listpubkeys
+```

--- a/deployment-scripts/azure/kms/services/ledger_cert_reconciler/function_src/Modules/Reconcile/Reconcile.psm1
+++ b/deployment-scripts/azure/kms/services/ledger_cert_reconciler/function_src/Modules/Reconcile/Reconcile.psm1
@@ -1,0 +1,142 @@
+# Copyright (c) iSPIRT.
+# Licensed under the Apache License, Version 2.0.
+#
+# Reconciles the Application Gateway's trusted root certificate for the
+# Confidential Ledger backend against the ledger's current TLS identity.
+#
+# When the Confidential Ledger (CCF) restarts, it regenerates its self-signed
+# service identity certificate. The gateway keeps trusting the previous cert,
+# so backend TLS validation fails and clients receive 502s. This function
+# fetches the live identity certificate and, if it differs from what is
+# currently stored on the gateway, updates the trusted root certificate.
+#
+# Steady-state runs compare against the certificate already on the gateway, so
+# a healthy deployment performs no writes. After an update, the thumbprint is
+# also stored as the gateway tag `ledgerRootThumbprint` as a fast path.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-LedgerIdentityCertificate {
+    param(
+        [Parameter(Mandatory = $true)][string]$BaseUrl,
+        [Parameter(Mandatory = $true)][string]$LedgerName
+    )
+
+    $uri = "{0}/ledgerIdentity/{1}" -f $BaseUrl.TrimEnd('/'), $LedgerName
+    $resp = Invoke-RestMethod -Method Get -Uri $uri -TimeoutSec 30
+    if (-not $resp.ledgerTlsCertificate) {
+        throw "Ledger identity endpoint returned no ledgerTlsCertificate for '$LedgerName' ($uri)."
+    }
+    return [string]$resp.ledgerTlsCertificate
+}
+
+function Get-StoredCertificateThumbprint {
+    param(
+        $TrustedRootCertificate
+    )
+
+    if (-not $TrustedRootCertificate -or -not $TrustedRootCertificate.Data) {
+        return $null
+    }
+
+    try {
+        $bytes = [Convert]::FromBase64String([string]$TrustedRootCertificate.Data)
+        # App Gateway returns base64 of PEM text (BEGIN CERTIFICATE...). Fall back
+        # to treating the decoded bytes as DER if PEM parsing fails.
+        $asText = [System.Text.Encoding]::ASCII.GetString($bytes)
+        if ($asText -match 'BEGIN CERTIFICATE') {
+            $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::CreateFromPem($asText)
+            return $cert.Thumbprint
+        }
+        $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($bytes)
+        return $cert.Thumbprint
+    }
+    catch {
+        Write-Warning ("Unable to parse stored trusted root certificate: " + $_.Exception.Message)
+        return $null
+    }
+}
+
+function Invoke-LedgerCertReconcile {
+    <#
+    .SYNOPSIS
+      Ensure the Application Gateway trusts the ledger's current TLS certificate.
+    .PARAMETER WhatIf
+      When set, reports whether an update is needed without writing.
+    #>
+    [CmdletBinding()]
+    param(
+        [switch]$WhatIf
+    )
+
+    $rg        = $env:AGW_RESOURCE_GROUP
+    $agwName   = $env:AGW_NAME
+    $ledger    = $env:LEDGER_NAME
+    $rootName  = if ($env:ROOT_CERT_NAME) { $env:ROOT_CERT_NAME } else { 'ledger-root-cert' }
+    $baseUrl   = if ($env:LEDGER_IDENTITY_BASE_URL) { $env:LEDGER_IDENTITY_BASE_URL } else { 'https://identity.confidential-ledger.core.azure.com' }
+
+    foreach ($pair in @{ AGW_RESOURCE_GROUP = $rg; AGW_NAME = $agwName; LEDGER_NAME = $ledger }.GetEnumerator()) {
+        if (-not $pair.Value) { throw "Required app setting '$($pair.Key)' is not set." }
+    }
+
+    $pem = Get-LedgerIdentityCertificate -BaseUrl $baseUrl -LedgerName $ledger
+    $liveCert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::CreateFromPem($pem)
+    $liveThumbprint = $liveCert.Thumbprint
+
+    $gw = Get-AzApplicationGateway -Name $agwName -ResourceGroupName $rg
+
+    # Prefer the certificate currently stored on the gateway so the first run
+    # is a true no-op when already correct. Tag is only a fallback.
+    $existing = Get-AzApplicationGatewayTrustedRootCertificate -ApplicationGateway $gw -Name $rootName -ErrorAction SilentlyContinue
+    $storedThumbprint = Get-StoredCertificateThumbprint -TrustedRootCertificate $existing
+    if (-not $storedThumbprint -and $gw.Tag -and $gw.Tag.ContainsKey('ledgerRootThumbprint')) {
+        $storedThumbprint = $gw.Tag['ledgerRootThumbprint']
+    }
+
+    if ($liveThumbprint -eq $storedThumbprint) {
+        return [pscustomobject]@{
+            changed    = $false
+            thumbprint = $liveThumbprint
+            message    = 'up-to-date'
+        }
+    }
+
+    if ($WhatIf) {
+        return [pscustomobject]@{
+            changed    = $true
+            thumbprint = $liveThumbprint
+            previous   = $storedThumbprint
+            message    = 'update-required (whatif)'
+        }
+    }
+
+    # App Gateway stores the trusted root cert as base64 of the PEM text
+    # (matches `az network application-gateway root-cert --cert-file`).
+    $dataB64 = [Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($pem))
+
+    if ($existing) {
+        Set-AzApplicationGatewayTrustedRootCertificate -ApplicationGateway $gw -Name $rootName -Data $dataB64 | Out-Null
+    }
+    else {
+        Add-AzApplicationGatewayTrustedRootCertificate -ApplicationGateway $gw -Name $rootName -Data $dataB64 | Out-Null
+    }
+
+    $tags = @{}
+    if ($gw.Tag) {
+        foreach ($k in $gw.Tag.Keys) { $tags[$k] = $gw.Tag[$k] }
+    }
+    $tags['ledgerRootThumbprint'] = $liveThumbprint
+    $gw.Tag = $tags
+
+    Set-AzApplicationGateway -ApplicationGateway $gw | Out-Null
+
+    return [pscustomobject]@{
+        changed    = $true
+        thumbprint = $liveThumbprint
+        previous   = $storedThumbprint
+        message    = 'updated'
+    }
+}
+
+Export-ModuleMember -Function Invoke-LedgerCertReconcile, Get-LedgerIdentityCertificate

--- a/deployment-scripts/azure/kms/services/ledger_cert_reconciler/function_src/ReconcileHttp/function.json
+++ b/deployment-scripts/azure/kms/services/ledger_cert_reconciler/function_src/ReconcileHttp/function.json
@@ -1,0 +1,19 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "name": "Request",
+      "type": "httpTrigger",
+      "direction": "in",
+      "methods": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "name": "Response",
+      "type": "http",
+      "direction": "out"
+    }
+  ]
+}

--- a/deployment-scripts/azure/kms/services/ledger_cert_reconciler/function_src/ReconcileHttp/run.ps1
+++ b/deployment-scripts/azure/kms/services/ledger_cert_reconciler/function_src/ReconcileHttp/run.ps1
@@ -1,0 +1,23 @@
+param($Request, $TriggerMetadata)
+
+# Triggered on demand (e.g. by an Azure Monitor action group when the ledger
+# backend goes unhealthy) to reconcile immediately instead of waiting for the
+# next timer tick.
+try {
+    $result = Invoke-LedgerCertReconcile
+    Write-Host ("ledger-cert reconcile (http): " + ($result | ConvertTo-Json -Compress))
+    Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+            StatusCode  = [System.Net.HttpStatusCode]::OK
+            ContentType = "application/json"
+            Body        = ($result | ConvertTo-Json -Compress)
+        })
+}
+catch {
+    $message = ($_ | Out-String)
+    Write-Error ("ledger-cert reconcile (http) failed: " + $message)
+    Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+            StatusCode  = [System.Net.HttpStatusCode]::InternalServerError
+            ContentType = "application/json"
+            Body        = (@{ error = $message } | ConvertTo-Json -Compress)
+        })
+}

--- a/deployment-scripts/azure/kms/services/ledger_cert_reconciler/function_src/ReconcileTimer/function.json
+++ b/deployment-scripts/azure/kms/services/ledger_cert_reconciler/function_src/ReconcileTimer/function.json
@@ -1,0 +1,10 @@
+{
+  "bindings": [
+    {
+      "name": "Timer",
+      "type": "timerTrigger",
+      "direction": "in",
+      "schedule": "%AGW_RECONCILE_SCHEDULE%"
+    }
+  ]
+}

--- a/deployment-scripts/azure/kms/services/ledger_cert_reconciler/function_src/ReconcileTimer/run.ps1
+++ b/deployment-scripts/azure/kms/services/ledger_cert_reconciler/function_src/ReconcileTimer/run.ps1
@@ -1,0 +1,10 @@
+param($Timer)
+
+try {
+    $result = Invoke-LedgerCertReconcile
+    Write-Host ("ledger-cert reconcile: " + ($result | ConvertTo-Json -Compress))
+}
+catch {
+    Write-Error ("ledger-cert reconcile failed: " + ($_ | Out-String))
+    throw
+}

--- a/deployment-scripts/azure/kms/services/ledger_cert_reconciler/function_src/host.json
+++ b/deployment-scripts/azure/kms/services/ledger_cert_reconciler/function_src/host.json
@@ -1,0 +1,16 @@
+{
+  "version": "2.0",
+  "managedDependency": {
+    "enabled": true
+  },
+  "functionTimeout": "00:10:00",
+  "logging": {
+    "logLevel": {
+      "default": "Information"
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/deployment-scripts/azure/kms/services/ledger_cert_reconciler/function_src/profile.ps1
+++ b/deployment-scripts/azure/kms/services/ledger_cert_reconciler/function_src/profile.ps1
@@ -1,0 +1,9 @@
+# Runs on each cold start. Authenticate to Azure using the Function App's
+# system-assigned managed identity so the reconcile module can call ARM.
+if ($env:MSI_SECRET -or $env:IDENTITY_ENDPOINT) {
+    Disable-AzContextAutosave -Scope Process | Out-Null
+    Connect-AzAccount -Identity -ErrorAction Stop | Out-Null
+    if ($env:SUBSCRIPTION_ID) {
+        Set-AzContext -Subscription $env:SUBSCRIPTION_ID -ErrorAction SilentlyContinue | Out-Null
+    }
+}

--- a/deployment-scripts/azure/kms/services/ledger_cert_reconciler/function_src/requirements.psd1
+++ b/deployment-scripts/azure/kms/services/ledger_cert_reconciler/function_src/requirements.psd1
@@ -1,0 +1,6 @@
+# Modules installed by the Functions host (managed dependencies).
+# Kept minimal to reduce cold-start time: only Accounts (auth) + Network (App Gateway).
+@{
+  'Az.Accounts' = '3.*'
+  'Az.Network'  = '7.*'
+}

--- a/deployment-scripts/azure/kms/services/ledger_cert_reconciler/main.tf
+++ b/deployment-scripts/azure/kms/services/ledger_cert_reconciler/main.tf
@@ -1,0 +1,240 @@
+# Copyright (c) iSPIRT.
+# Licensed under the Apache License, Version 2.0.
+#
+# Ledger certificate reconciler.
+#
+# When the Confidential Ledger (CCF) restarts it regenerates its self-signed
+# TLS identity certificate. The Application Gateway pins that certificate as the
+# trusted root for the ledger backend, so a rotation breaks backend TLS and
+# clients get 502s until the gateway is updated.
+#
+# This module deploys a PowerShell Function App that:
+#   - Timer trigger (default: every minute) reconciles the gateway's trusted
+#     root certificate against the ledger's live identity certificate.
+#   - HTTP trigger performs the same reconcile on demand; it is wired to an
+#     UnhealthyHostCount metric alert (via an action group) for immediate
+#     reaction when a rotation is detected.
+#
+# The function authenticates with a system-assigned managed identity that is
+# granted a custom role scoped to the single Application Gateway.
+
+locals {
+  service_plan_name    = var.service_plan_name != "" ? var.service_plan_name : "${var.function_app_name}-plan"
+  role_definition_name = var.role_definition_name != "" ? var.role_definition_name : "${var.function_app_name}-agw-writer"
+
+  app_settings = {
+    FUNCTIONS_WORKER_RUNTIME = "powershell"
+    WEBSITE_RUN_FROM_PACKAGE = "${azurerm_storage_blob.package.url}${data.azurerm_storage_account_sas.package.sas}"
+    AGW_RESOURCE_GROUP       = var.resource_group_name
+    AGW_NAME                 = var.application_gateway_name
+    LEDGER_NAME              = var.ledger_name
+    ROOT_CERT_NAME           = var.trusted_root_certificate_name
+    LEDGER_IDENTITY_BASE_URL = var.ledger_identity_base_url
+    SUBSCRIPTION_ID          = var.subscription_id
+    AGW_RECONCILE_SCHEDULE   = var.reconcile_schedule
+  }
+}
+
+# --- Package the function code -------------------------------------------------
+
+data "archive_file" "package" {
+  type        = "zip"
+  source_dir  = "${path.module}/function_src"
+  output_path = "${path.module}/build/ledger_cert_reconciler.zip"
+}
+
+# --- Storage account for the Function App -------------------------------------
+
+resource "azurerm_storage_account" "this" {
+  name                            = var.storage_account_name
+  resource_group_name             = var.resource_group_name
+  location                        = var.location
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
+  min_tls_version                 = "TLS1_2"
+  allow_nested_items_to_be_public = false
+  tags                            = var.tags
+}
+
+resource "azurerm_storage_container" "deployments" {
+  name                  = "deployments"
+  storage_account_id    = azurerm_storage_account.this.id
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_blob" "package" {
+  name                   = "ledger_cert_reconciler-${data.archive_file.package.output_md5}.zip"
+  storage_account_name   = azurerm_storage_account.this.name
+  storage_container_name = azurerm_storage_container.deployments.name
+  type                   = "Block"
+  source                 = data.archive_file.package.output_path
+  content_md5            = data.archive_file.package.output_md5
+}
+
+# Read-only SAS so the Functions host can pull the package (run-from-package).
+data "azurerm_storage_account_sas" "package" {
+  connection_string = azurerm_storage_account.this.primary_connection_string
+  https_only        = true
+  signed_version    = "2021-06-08"
+
+  resource_types {
+    service   = false
+    container = false
+    object    = true
+  }
+
+  services {
+    blob  = true
+    queue = false
+    table = false
+    file  = false
+  }
+
+  # Static window to avoid perpetual plan diffs; long-lived read-only package SAS.
+  start  = "2024-01-01T00:00:00Z"
+  expiry = "2099-01-01T00:00:00Z"
+
+  permissions {
+    read    = true
+    write   = false
+    delete  = false
+    list    = false
+    add     = false
+    create  = false
+    update  = false
+    process = false
+    tag     = false
+    filter  = false
+  }
+}
+
+# --- Function App -------------------------------------------------------------
+
+resource "azurerm_service_plan" "this" {
+  name                = local.service_plan_name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  # Windows: PowerShell Functions are supported on Windows Consumption (Y1).
+  os_type  = "Windows"
+  sku_name = "Y1"
+  tags     = var.tags
+}
+
+resource "azurerm_windows_function_app" "this" {
+  name                       = var.function_app_name
+  resource_group_name        = var.resource_group_name
+  location                   = var.location
+  service_plan_id            = azurerm_service_plan.this.id
+  storage_account_name       = azurerm_storage_account.this.name
+  storage_account_access_key = azurerm_storage_account.this.primary_access_key
+  https_only                 = true
+  tags                       = var.tags
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  site_config {
+    application_stack {
+      powershell_core_version = "7.4"
+    }
+  }
+
+  app_settings = local.app_settings
+
+  lifecycle {
+    ignore_changes = [
+      # The Functions host manages the content share connection string.
+      app_settings["WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"],
+      app_settings["WEBSITE_CONTENTSHARE"],
+    ]
+  }
+}
+
+# --- Least-privilege RBAC scoped to the single Application Gateway -------------
+
+resource "azurerm_role_definition" "reconciler" {
+  name        = local.role_definition_name
+  scope       = var.application_gateway_id
+  description = "Read/write the ledger trusted-root certificate on this Application Gateway."
+
+  permissions {
+    actions = [
+      "Microsoft.Network/applicationGateways/read",
+      "Microsoft.Network/applicationGateways/write",
+      "Microsoft.Network/applicationGateways/backendHealth/action",
+    ]
+    not_actions = []
+  }
+
+  assignable_scopes = [var.application_gateway_id]
+}
+
+resource "azurerm_role_assignment" "reconciler" {
+  scope              = var.application_gateway_id
+  role_definition_id = azurerm_role_definition.reconciler.role_definition_resource_id
+  principal_id       = azurerm_windows_function_app.this.identity[0].principal_id
+}
+
+# --- Immediate reaction: UnhealthyHostCount alert -> function HTTP trigger -----
+
+data "azurerm_function_app_host_keys" "this" {
+  count = var.alert_enabled ? 1 : 0
+
+  name                = azurerm_windows_function_app.this.name
+  resource_group_name = var.resource_group_name
+
+  depends_on = [azurerm_windows_function_app.this]
+}
+
+resource "azurerm_monitor_action_group" "this" {
+  count = var.alert_enabled ? 1 : 0
+
+  name                = "${var.function_app_name}-ag"
+  resource_group_name = var.resource_group_name
+  # Action group short_name must be ≤12 alphanumeric chars.
+  short_name = substr(replace(replace(lower(var.function_app_name), "-", ""), ".", ""), 0, 12)
+  location            = "global"
+  tags                = var.tags
+
+  azure_function_receiver {
+    name                     = "reconcile"
+    function_app_resource_id = azurerm_windows_function_app.this.id
+    function_name            = "ReconcileHttp"
+    http_trigger_url         = "https://${azurerm_windows_function_app.this.default_hostname}/api/ReconcileHttp?code=${data.azurerm_function_app_host_keys.this[0].default_function_key}"
+    use_common_alert_schema  = true
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "ledger_backend_unhealthy" {
+  count = var.alert_enabled ? 1 : 0
+
+  name                = "${var.application_gateway_name}-ledger-cert-rotation"
+  resource_group_name = var.resource_group_name
+  scopes              = [var.application_gateway_id]
+  description         = "Ledger backend unhealthy on ${var.application_gateway_name}; triggers immediate trusted-root cert reconcile."
+
+  severity      = var.alert_severity
+  enabled       = true
+  auto_mitigate = true
+  frequency     = var.alert_frequency
+  window_size   = var.alert_window_size
+
+  criteria {
+    aggregation      = "Average"
+    metric_namespace = "Microsoft.Network/applicationGateways"
+    metric_name      = "UnhealthyHostCount"
+    operator         = "GreaterThan"
+    threshold        = 0
+
+    dimension {
+      name     = "BackendSettingsPool"
+      operator = "Include"
+      values   = [var.ledger_backend_http_settings_name]
+    }
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.this[0].id
+  }
+}

--- a/deployment-scripts/azure/kms/services/ledger_cert_reconciler/outputs.tf
+++ b/deployment-scripts/azure/kms/services/ledger_cert_reconciler/outputs.tf
@@ -1,0 +1,37 @@
+# Copyright (c) iSPIRT.
+# Licensed under the Apache License, Version 2.0.
+
+output "function_app_id" {
+  description = "Resource ID of the reconciler Function App."
+  value       = azurerm_windows_function_app.this.id
+}
+
+output "function_app_name" {
+  description = "Name of the reconciler Function App."
+  value       = azurerm_windows_function_app.this.name
+}
+
+output "function_app_default_hostname" {
+  description = "Default hostname of the reconciler Function App."
+  value       = azurerm_windows_function_app.this.default_hostname
+}
+
+output "function_identity_principal_id" {
+  description = "Principal ID of the Function App's system-assigned managed identity."
+  value       = azurerm_windows_function_app.this.identity[0].principal_id
+}
+
+output "role_definition_id" {
+  description = "ID of the custom role granted to the function identity."
+  value       = azurerm_role_definition.reconciler.role_definition_resource_id
+}
+
+output "action_group_id" {
+  description = "Action group ID that invokes the function on unhealthy backend (null when alert_enabled = false)."
+  value       = var.alert_enabled ? azurerm_monitor_action_group.this[0].id : null
+}
+
+output "metric_alert_id" {
+  description = "Metric alert ID for ledger backend health (null when alert_enabled = false)."
+  value       = var.alert_enabled ? azurerm_monitor_metric_alert.ledger_backend_unhealthy[0].id : null
+}

--- a/deployment-scripts/azure/kms/services/ledger_cert_reconciler/variables.tf
+++ b/deployment-scripts/azure/kms/services/ledger_cert_reconciler/variables.tf
@@ -1,0 +1,113 @@
+# Copyright (c) iSPIRT.
+# Licensed under the Apache License, Version 2.0.
+
+variable "resource_group_name" {
+  type        = string
+  description = "Resource group that hosts the Application Gateway and where the reconciler resources are created."
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region for the reconciler resources."
+}
+
+variable "subscription_id" {
+  type        = string
+  description = "Subscription ID that contains the Application Gateway (used by the function to set its ARM context)."
+}
+
+variable "application_gateway_id" {
+  type        = string
+  description = "Resource ID of the Application Gateway whose ledger trusted-root certificate is reconciled."
+}
+
+variable "application_gateway_name" {
+  type        = string
+  description = "Name of the Application Gateway."
+}
+
+variable "ledger_name" {
+  type        = string
+  description = "Confidential Ledger name (used to fetch the current TLS identity certificate)."
+}
+
+variable "trusted_root_certificate_name" {
+  type        = string
+  description = "Name of the trusted root certificate entry on the Application Gateway backend HTTP settings."
+  default     = "ledger-root-cert"
+}
+
+variable "ledger_identity_base_url" {
+  type        = string
+  description = "Base URL of the Confidential Ledger identity service."
+  default     = "https://identity.confidential-ledger.core.azure.com"
+}
+
+variable "storage_account_name" {
+  type        = string
+  description = "Globally unique storage account name for the Function App (<=24 lowercase alphanumeric chars)."
+
+  validation {
+    condition     = can(regex("^[a-z0-9]{3,24}$", var.storage_account_name))
+    error_message = "storage_account_name must be 3-24 lowercase alphanumeric characters."
+  }
+}
+
+variable "function_app_name" {
+  type        = string
+  description = "Name of the Function App that runs the reconciler."
+}
+
+variable "service_plan_name" {
+  type        = string
+  description = "Name of the App Service (consumption) plan. Defaults to <function_app_name>-plan when empty."
+  default     = ""
+}
+
+variable "reconcile_schedule" {
+  type        = string
+  description = "NCRONTAB schedule for the timer trigger. Default: every minute."
+  default     = "0 */1 * * * *"
+}
+
+variable "role_definition_name" {
+  type        = string
+  description = "Name for the custom role granted to the function identity (scoped to the Application Gateway). Defaults to <function_app_name>-agw-writer when empty."
+  default     = ""
+}
+
+variable "alert_enabled" {
+  type        = bool
+  description = "If true, create an UnhealthyHostCount metric alert on the gateway wired to an action group that calls the function's HTTP trigger for immediate reconciliation."
+  default     = true
+}
+
+variable "alert_severity" {
+  type        = number
+  description = "Severity (0-4) for the ledger-backend-unhealthy alert."
+  default     = 1
+}
+
+variable "alert_frequency" {
+  type        = string
+  description = "How often the alert rule evaluates (ISO8601 duration, e.g. PT1M)."
+  default     = "PT1M"
+}
+
+variable "alert_window_size" {
+  type        = string
+  description = "Aggregation window for the alert (ISO8601 duration, e.g. PT5M)."
+  default     = "PT5M"
+}
+
+variable "ledger_backend_http_settings_name" {
+  type        = string
+  description = "Backend HTTP settings name that routes to the ledger (metric dimension BackendSettingsPool)."
+  default     = "depa-inferencing-backend-http-settings"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags applied to the reconciler resources."
+  default     = {}
+}

--- a/deployment-scripts/azure/kms/services/ledger_cert_reconciler/versions.tf
+++ b/deployment-scripts/azure/kms/services/ledger_cert_reconciler/versions.tf
@@ -1,0 +1,17 @@
+# Copyright (c) iSPIRT.
+# Licensed under the Apache License, Version 2.0.
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.54"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.4"
+    }
+  }
+}


### PR DESCRIPTION
- Documented manual frontend TLS renewal (DNS-01 → Key Vault → App Gateway force-refresh) for environments that lack the automated Let's Encrypt workflow (notably older prod). UAT continues to use `refresh_kms_frontend_certificate.yml`.
- Introduced a ledger cert reconciler (Azure Function + Terraform): when Confidential Ledger restarts and its TLS identity rotates, keep the App Gateway trusted root in sync so clients don't hit 502s. The reconciler continuously polls every minute to minimize any downtime.
